### PR TITLE
src/Classic/Structure/LossDataSink.cpp

### DIFF
--- a/src/Classic/Structure/LossDataSink.cpp
+++ b/src/Classic/Structure/LossDataSink.cpp
@@ -77,7 +77,7 @@ void LossDataSink::openH5(h5_int32_t mode) {
     h5_prop_t props = H5CreateFileProp ();
     MPI_Comm comm = Ippl::getComm();
     H5SetPropFileMPIOCollective (props, &comm);
-    H5file_m = H5OpenFile (fn_m.c_str(), H5_O_RDONLY, props);
+    H5file_m = H5OpenFile (fn_m.c_str(), mode, props);
 
     if(H5file_m == (h5_file_t)H5_ERR) {
         throw GeneralClassicException("LossDataSink::openH5",
@@ -85,7 +85,7 @@ void LossDataSink::openH5(h5_int32_t mode) {
     }
 #else
 
-    H5file_m = H5OpenFile(fn_m.c_str(), H5_O_WRONLY, Ippl::getComm());
+    H5file_m = H5OpenFile(fn_m.c_str(), mode, Ippl::getComm());
     if(H5file_m == (void*)H5_ERR) {
         throw GeneralClassicException("LossDataSink::openH5",
                                       "failed to open h5 file '" + fn_m + "'");
@@ -170,14 +170,12 @@ void LossDataSink::save(unsigned int numSets) {
             openH5();
             writeHeaderH5();
         } else {
-            openH5(H5_O_RDONLY);
-            H5call_m = H5GetNumSteps(H5file_m);
-            H5CloseFile(H5file_m);
 #ifdef H5HUT_API_VERSION
             openH5(H5_O_APPENDONLY);
 #else
             openH5(H5_O_APPEND);
 #endif
+            H5call_m = H5GetNumSteps(H5file_m);
         }
 
         splitSets(numSets);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [src/Classic/Structure/LossDataSink.cpp](https://gitlab.psi.ch/OPAL/src/merge_requests/7) |
> | **GitLab MR Number** | [7](https://gitlab.psi.ch/OPAL/src/merge_requests/7) |
> | **Date Originally Opened** | Fri, 10 Feb 2017 |
> | **Date Originally Merged** | Fri, 10 Feb 2017 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- openH5(mode): passed mode argument was not used, H5_O_RDONLY was
  hard-coded in case of H5hut 2 (fixes issue #29)
- save(): read number of steps after opening file in append mode

Closes #29