### PR TITLE
Revert "libgfortran removed from link libraries"

### DIFF
--- a/ippl/test/AMR/amrex-only/CMakeLists.txt
+++ b/ippl/test/AMR/amrex-only/CMakeLists.txt
@@ -72,22 +72,22 @@ if ( ${BL_SPACEDIM} EQUAL 3 )
                        COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/inputs $<TARGET_FILE_DIR:testDeposition>)
 
     target_link_libraries (testDeposition ${LIBS}
-                           ${AMREX_LIBRARIES}
+                           -lgfortran ${AMREX_LIBRARIES}
                            ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
                         
     target_link_libraries (AssignMultiLevelDensity ${LIBS}
-                           ${AMREX_LIBRARIES}
+                           -lgfortran ${AMREX_LIBRARIES}
                            ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
     target_link_libraries (testGeometry ${LIBS}
-                           ${AMREX_LIBRARIES}
+                           -lgfortran ${AMREX_LIBRARIES}
                            ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
     target_link_libraries (testDepositionFail ${LIBS}
-                           ${AMREX_LIBRARIES}
+                           -lgfortran ${AMREX_LIBRARIES}
                            ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
     target_link_libraries (testSolverFail ${LIBS}
-                           ${AMREX_LIBRARIES}
+                           -lgfortran ${AMREX_LIBRARIES}
                            ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 endif()

--- a/ippl/test/AMR/boxlib-amr/CMakeLists.txt
+++ b/ippl/test/AMR/boxlib-amr/CMakeLists.txt
@@ -157,66 +157,66 @@ add_executable (testOldPerformance
                 ../Solver.cpp)
     
     # Boxlib has a circular dependency between -lcboxlib and -lfboxlib --> resolve by: -lcboxlib -lfboxlib -lcboxlib
-#     target_link_libraries (testAmrPartBunch ${LIBS} ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
-#     target_link_libraries (testSolver ${LIBS} ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
-#     target_link_libraries (testError ${LIBS} ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
+#     target_link_libraries (testAmrPartBunch ${LIBS} -lgfortran ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
+#     target_link_libraries (testSolver ${LIBS} -lgfortran ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
+#     target_link_libraries (testError ${LIBS} -lgfortran ${AMREX_LIBRARIES} -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (iterative)
 
 target_link_libraries (testH5Read ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testHdf5 ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testGaussian ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testUniform ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testUnifSphere ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
                         
 target_link_libraries (testGridSolve ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testUnifSphereGrid ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testReal ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testMultiBunch ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (toFile ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testTracker ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
     
 target_link_libraries (testOldPlasma ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS}
                         -lboost_system -lboost_filesystem)
     
 target_link_libraries (testPerfectLoadBalancing ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testOldPerformance ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         -lcboxlib ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 

--- a/ippl/test/AMR/ippl-amr/CMakeLists.txt
+++ b/ippl/test/AMR/ippl-amr/CMakeLists.txt
@@ -192,50 +192,50 @@ add_custom_command(TARGET testScatterAMReX POST_BUILD
 
 
 target_link_libraries (testAmrPartBase ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testNewTracker ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testPerformance ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testPlasma ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS}
                         -lboost_system -lboost_filesystem)
 
 target_link_libraries (testTagging ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 # target_link_libraries (testInitGuessSolver ${LIBS}
-#                         ${AMREX_LIBRARIES}
+#                         -lgfortran ${AMREX_LIBRARIES}
 #                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testInitialBox ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testScatterAMReX ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testDomainTransformSolve ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testGaussian ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testUnifSphere ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testLayout ${LIBS}
-                        ${AMREX_LIBRARIES}
+                        -lgfortran ${AMREX_LIBRARIES}
                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})

--- a/ippl/test/AMR/ippl-bunch/CMakeLists.txt
+++ b/ippl/test/AMR/ippl-bunch/CMakeLists.txt
@@ -70,9 +70,9 @@ add_executable( testAdapterPattern
                )
 
 # target_link_libraries (testCRTP ${LIBS}
-#                         ${AMREX_LIBRARIES}
+#                         -lgfortran ${AMREX_LIBRARIES}
 #                         ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 target_link_libraries (testAdapterPattern ${LIBS}
-                       ${AMREX_LIBRARIES}
+                       -lgfortran ${AMREX_LIBRARIES}
                        ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})

--- a/opt-pilot/Drivers/pisa-opal/CMakeLists.txt
+++ b/opt-pilot/Drivers/pisa-opal/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries( pisa-opal.exe
     OPALib
     ${MPI_CXX_LIBRARIES}
     ${Trilinos_LIBRARIES}
+    -lgfortran
     ${OPTP_LIBS}
     ${Boost_LIBRARIES}
     z

--- a/opt-pilot/Drivers/pisa-standalone/CMakeLists.txt
+++ b/opt-pilot/Drivers/pisa-standalone/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries ( pisa-standalone.exe
     ${OPTP_LIBRARY}
     ${BOOST_FILESYSTEM}
     ${MPI_CXX_LIBRARIES}
+    -lgfortran
     )
 
 message(STATUS "OPTP_LIBRARY ${OPTP_LIBRARY}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,7 +152,7 @@ set_target_properties( OPALib PROPERTIES OUTPUT_NAME OPAL )
 target_link_libraries( OPALib ${OPAL_LIBS} ${Trilinos_LIBRARIES} ${AMREX_LIBRARIES} ${OTHER_CMAKE_EXE_LINKER_FLAGS} )
 
 add_executable( opal Main.cpp )
-target_link_libraries( opal ${OPAL_LIBS} OPALib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES} ${AMREX_LIBRARIES} ${F_MPI} ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
+target_link_libraries( opal ${OPAL_LIBS} OPALib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES} -lgfortran ${AMREX_LIBRARIES} ${F_MPI} ${OTHER_CMAKE_EXE_LINKER_FLAGS} ${CMAKE_DL_LIBS})
 
 install (TARGETS ${TEST_EXE} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 install (TARGETS opal RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Revert "libgfortran removed from link li...](https://gitlab.psi.ch/OPAL/src/merge_requests/22) |
> | **GitLab MR Number** | [22](https://gitlab.psi.ch/OPAL/src/merge_requests/22) |
> | **Date Originally Opened** | Fri, 8 Dec 2017 |
> | **Date Originally Merged** | Fri, 8 Dec 2017 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

This reverts commit 0beafc91f118cb5b6f06fb82915409461d707499