### PR TITLE
Resolve: "reading H5hut fieldmap fails due to unset view"

### DIFF
--- a/src/Classic/Fields/FM3DH5Block.cpp
+++ b/src/Classic/Fields/FM3DH5Block.cpp
@@ -240,6 +240,11 @@ void FM3DH5Block::readMap() {
     FieldstrengthHx_m.resize(field_size);
     FieldstrengthHy_m.resize(field_size);
     FieldstrengthHz_m.resize(field_size);
+    h5err = H5Block3dSetView(file,
+                             0, num_gridpx_m - 1,
+                             0, num_gridpy_m - 1,
+                             0, num_gridpz_m - 1);
+    assert (h5err != H5_ERR);
     h5err = H5Block3dReadVector3dFieldFloat64(
         file,
         "Efield",


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve: "reading H5hut fieldmap fails d...](https://gitlab.psi.ch/OPAL/src/merge_requests/66) |
> | **GitLab MR Number** | [66](https://gitlab.psi.ch/OPAL/src/merge_requests/66) |
> | **Date Originally Opened** | Tue, 2 Apr 2019 |
> | **Date Originally Merged** | Wed, 3 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

This merge request fixes the issue reading fieldmaps in H5Block format

Closes #292