### PR TITLE
Use a more suitable name instead of getCoordTransformationTo

### DIFF
--- a/src/Algorithms/ParallelSliceTracker.cpp
+++ b/src/Algorithms/ParallelSliceTracker.cpp
@@ -22,7 +22,7 @@ ParallelSliceTracker::ParallelSliceTracker(const Beamline &beamline,
     Tracker(beamline, reference, revBeam, revTrack) {
 
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo().conjugate());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 
 }
@@ -46,7 +46,7 @@ ParallelSliceTracker::ParallelSliceTracker(const Beamline &beamline,
     itsDataSink_m   = &ds;
 
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 
     for (std::vector<unsigned long long>::const_iterator it = maxSteps.begin(); it != maxSteps.end(); ++ it) {
@@ -78,7 +78,7 @@ ParallelSliceTracker::~ParallelSliceTracker()
 void ParallelSliceTracker::visitBeamline(const Beamline &bl) { // borrowed from ParallelTTracker
     const FlaggedBeamline* fbl = static_cast<const FlaggedBeamline*>(&bl);
     if (fbl->getRelativeFlag()) {
-        OpalBeamline stash(fbl->getOrigin3D(), fbl->getCoordTransformationTo());
+        OpalBeamline stash(fbl->getOrigin3D(), fbl->getInitialDirection());
         stash.swap(itsOpalBeamline_m);
         fbl->iterate(*this, false);
         itsOpalBeamline_m.prepareSections();

--- a/src/Algorithms/ParallelTTracker.cpp
+++ b/src/Algorithms/ParallelTTracker.cpp
@@ -60,7 +60,7 @@ ParallelTTracker::ParallelTTracker(const Beamline &beamline,
                                    bool revTrack):
     Tracker(beamline, reference, revBeam, revTrack),
     itsDataSink_m(NULL),
-    itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getCoordTransformationTo()),
+    itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getInitialDirection()),
     RefPartR_m(0.0),
     RefPartP_m(0.0),
     globalEOL_m(false),
@@ -88,7 +88,7 @@ ParallelTTracker::ParallelTTracker(const Beamline &beamline,
 {
 
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo().conjugate());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 
 #ifdef OPAL_DKS
@@ -109,7 +109,7 @@ ParallelTTracker::ParallelTTracker(const Beamline &beamline,
                                    const std::vector<double> &dt):
     Tracker(beamline, bunch, reference, revBeam, revTrack),
     itsDataSink_m(&ds),
-    itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getCoordTransformationTo()),
+    itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getInitialDirection()),
     RefPartR_m(0.0),
     RefPartP_m(0.0),
     globalEOL_m(false),
@@ -134,7 +134,7 @@ ParallelTTracker::ParallelTTracker(const Beamline &beamline,
 {
 
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 
     for (std::vector<unsigned long long>::const_iterator it = maxSteps.begin(); it != maxSteps.end(); ++ it) {
@@ -259,6 +259,7 @@ void ParallelTTracker::execute() {
 
         restoreCavityPhases();
     } else {
+
         RefPartR_m = Vector_t(0.0);
         RefPartP_m = euclidean_norm(itsBunch_m->get_pmean_Distribution()) * Vector_t(0, 0, 1);
 

--- a/src/Algorithms/ThickTracker.cpp
+++ b/src/Algorithms/ThickTracker.cpp
@@ -43,7 +43,7 @@ ThickTracker::ThickTracker(const Beamline &beamline,
     , RefPartR_m(0.0)
     , RefPartP_m(0.0)
     , itsDataSink_m(nullptr)
-    , itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getCoordTransformationTo())
+    , itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getInitialDirection())
     , zstart_m(0.0)
     , zstop_m(0.0)
     , threshold_m(1.0e-6)
@@ -53,7 +53,7 @@ ThickTracker::ThickTracker(const Beamline &beamline,
     , mapTracking_m(   IpplTimings::getTimer("mapTracking"))
 {
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 }
 
@@ -74,7 +74,7 @@ ThickTracker::ThickTracker(const Beamline &beamline,
     , RefPartR_m(0.0)
     , RefPartP_m(0.0)
     , itsDataSink_m(&ds)
-    , itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getCoordTransformationTo())
+    , itsOpalBeamline_m(beamline.getOrigin3D(), beamline.getInitialDirection())
     , zstart_m(zstart)
     , zstop_m(zstop[0])
     , threshold_m(1.0e-6)
@@ -89,7 +89,7 @@ ThickTracker::ThickTracker(const Beamline &beamline,
 
 
     CoordinateSystemTrafo labToRef(beamline.getOrigin3D(),
-                                   beamline.getCoordTransformationTo());
+                                   beamline.getInitialDirection());
     referenceToLabCSTrafo_m = labToRef.inverted();
 }
 
@@ -104,7 +104,7 @@ void ThickTracker::visitBeamline(const Beamline &bl) {
     const FlaggedBeamline* fbl = static_cast<const FlaggedBeamline*>(&bl);
     if (fbl->getRelativeFlag()) {
         *gmsg << " do stuff" << endl;
-        OpalBeamline stash(fbl->getOrigin3D(), fbl->getCoordTransformationTo());
+        OpalBeamline stash(fbl->getOrigin3D(), fbl->getInitialDirection());
         stash.swap(itsOpalBeamline_m);
         fbl->iterate(*this, false);
         itsOpalBeamline_m.prepareSections();

--- a/src/Classic/Beamlines/Beamline.cpp
+++ b/src/Classic/Beamlines/Beamline.cpp
@@ -50,7 +50,7 @@ Vector_t Beamline::getOrigin3D() const {
     return Vector_t(0);
 }
 
-Quaternion Beamline::getCoordTransformationTo() const {
+Quaternion Beamline::getInitialDirection() const {
     return Quaternion(1, 0, 0, 0);
 }
 

--- a/src/Classic/Beamlines/Beamline.h
+++ b/src/Classic/Beamlines/Beamline.h
@@ -52,7 +52,7 @@ public:
     virtual void iterate(BeamlineVisitor &, bool reverse) const = 0;
 
     virtual Vector_t getOrigin3D() const;
-    virtual Quaternion getCoordTransformationTo() const;
+    virtual Quaternion getInitialDirection() const;
     virtual bool getRelativeFlag() const;
 private:
 

--- a/src/Elements/OpalBeamline.cpp
+++ b/src/Elements/OpalBeamline.cpp
@@ -19,11 +19,11 @@ OpalBeamline::OpalBeamline():
 }
 
 OpalBeamline::OpalBeamline(const Vector_t& origin,
-                           const Quaternion& coordTransformationTo):
+                           const Quaternion& rotation):
     elements_m(),
     prepared_m(false),
     containsSource_m(false),
-    coordTransformationTo_m(origin, coordTransformationTo)
+    coordTransformationTo_m(origin, rotation)
 {
 }
 

--- a/src/Elements/OpalBeamline.h
+++ b/src/Elements/OpalBeamline.h
@@ -41,7 +41,7 @@ class OpalBeamline {
 public:
     OpalBeamline();
     OpalBeamline(const Vector_t& origin,
-                 const Quaternion& coordTrafoTo);
+                 const Quaternion& rotation);
     ~OpalBeamline();
 
     OpalSection &getSectionAt(const Vector_t &, long &);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Use a more suitable name instead of getC...](https://gitlab.psi.ch/OPAL/src/merge_requests/67) |
> | **GitLab MR Number** | [67](https://gitlab.psi.ch/OPAL/src/merge_requests/67) |
> | **Date Originally Opened** | Tue, 2 Apr 2019 |
> | **Date Originally Merged** | Tue, 2 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

The beamline class doesn't return a coordinate transformation but instead the initial direction.