### PR TITLE
iostream instances aren't movable in older gcc.

### DIFF
--- a/src/Algorithms/ParallelCyclotronTracker.cpp
+++ b/src/Algorithms/ParallelCyclotronTracker.cpp
@@ -246,9 +246,9 @@ void ParallelCyclotronTracker::bgf_main_collision_test() {
  *
  * @param fn Base file name
  */
-void ParallelCyclotronTracker::openFiles(std::string SfileName) {
+void ParallelCyclotronTracker::openFiles(size_t numFiles, std::string SfileName) {
 
-    for (unsigned int i=0; i<outfTheta_m.size(); i++) {
+    for (unsigned int i=0; i<numFiles; i++) {
         std::string SfileName2 = SfileName;
         if (i<=2) {
             SfileName2 += std::string("-Angle" + std::to_string(int(i)) + ".dat");
@@ -258,12 +258,12 @@ void ParallelCyclotronTracker::openFiles(std::string SfileName) {
             SfileName2 += std::string("-afterEachTurn.dat");
         }
 
-        outfTheta_m[i].precision(8);
-        outfTheta_m[i].setf(std::ios::scientific, std::ios::floatfield);
-        outfTheta_m[i].open(SfileName2.c_str());
-        outfTheta_m[i] << "# r [mm]        beta_r*gamma       "
-                       << "theta [deg]     beta_theta*gamma        "
-                       << "z [mm]          beta_z*gamma" << std::endl;
+        outfTheta_m.emplace_back(new std::ofstream(SfileName2.c_str()));
+        outfTheta_m.back()->precision(8);
+        outfTheta_m.back()->setf(std::ios::scientific, std::ios::floatfield);
+        *outfTheta_m.back() << "# r [mm]        beta_r*gamma       "
+                            << "theta [deg]     beta_theta*gamma        "
+                            << "z [mm]          beta_z*gamma" << std::endl;
     }
 }
 
@@ -274,7 +274,7 @@ void ParallelCyclotronTracker::openFiles(std::string SfileName) {
  */
 void ParallelCyclotronTracker::closeFiles() {
     for (auto & file : outfTheta_m) {
-        file.close();
+        file->close();
     }
 }
 
@@ -2886,7 +2886,6 @@ std::tuple<double, double, double> ParallelCyclotronTracker::initializeTracking_
     azimuth_angle_m[0] = 0.0;
     azimuth_angle_m[1] = 22.5 * Physics::deg2rad;
     azimuth_angle_m[2] = 45.0 * Physics::deg2rad;
-    outfTheta_m.resize(azimuth_angle_m.size() + 1); // 1 more for file after every turn
 
     double harm       = getHarmonicNumber();
     double dt         = itsBunch_m->getdT() * 1.0e9 * harm; // time step size (s --> ns)
@@ -2969,7 +2968,7 @@ std::tuple<double, double, double> ParallelCyclotronTracker::initializeTracking_
                                     "SINGLE PARTICLE MODE ONLY WORKS SERIALLY ON A SINGLE NODE!");
 
             // For single particle mode open output files
-            openFiles(OpalData::getInstance()->getInputBasename());
+            openFiles(azimuth_angle_m.size() + 1, OpalData::getInstance()->getInputBasename());
             break;
         case MODE::BUNCH:
             break;
@@ -3323,16 +3322,16 @@ void ParallelCyclotronTracker::dumpAzimuthAngles_m(const double& t,
     for (unsigned int i=0; i<=2; i++) {
         if ((oldReferenceTheta < azimuth_angle_m[i] - setup_m.deltaTheta) &&
             (  temp_meanTheta >= azimuth_angle_m[i] - setup_m.deltaTheta)) {
-            outfTheta_m[i] << "#Turn number = " << turnnumber_m
-                           << ", Time = " << t << " [ns]" << std::endl
-                           << " " << std::hypot(R(0), R(1))
-                           << " " << P(0) * std::cos(temp_meanTheta) + P(1) * std::sin(temp_meanTheta)
-                           << " " << temp_meanTheta * Physics::rad2deg
-                           << " " << - P(0) * std::sin(temp_meanTheta) + P(1) * std::cos(temp_meanTheta)
-                           << " " << R(2)
-                           << " " << P(2) << std::endl;
+            *(outfTheta_m[i]) << "#Turn number = " << turnnumber_m
+                              << ", Time = " << t << " [ns]" << std::endl
+                              << " " << std::hypot(R(0), R(1))
+                              << " " << P(0) * std::cos(temp_meanTheta) + P(1) * std::sin(temp_meanTheta)
+                              << " " << temp_meanTheta * Physics::rad2deg
+                              << " " << - P(0) * std::sin(temp_meanTheta) + P(1) * std::cos(temp_meanTheta)
+                              << " " << R(2)
+                              << " " << P(2) << std::endl;
+            }
         }
-    }
 }
 
 void ParallelCyclotronTracker::dumpThetaEachTurn_m(const double& t,
@@ -3349,16 +3348,16 @@ void ParallelCyclotronTracker::dumpThetaEachTurn_m(const double& t,
 
         *gmsg << "* SPT: Finished turn " << turnnumber_m - 1 << endl;
 
-        outfTheta_m[3] << "#Turn number = " << turnnumber_m
-                       << ", Time = " << t << " [ns]" << std::endl
-                       << " " << std::sqrt(R(0) * R(0) + R(1) * R(1))
-                       << " " << P(0) * std::cos(temp_meanTheta) +
-                                 P(1) * std::sin(temp_meanTheta)
-                       << " " << temp_meanTheta / Physics::deg2rad
-                       << " " << - P(0) * std::sin(temp_meanTheta) +
-                                   P(1) * std::cos(temp_meanTheta)
-                       << " " << R(2)
-                       << " " << P(2) << std::endl;
+        *(outfTheta_m[3]) << "#Turn number = " << turnnumber_m
+                          << ", Time = " << t << " [ns]" << std::endl
+                          << " " << std::sqrt(R(0) * R(0) + R(1) * R(1))
+                          << " " << P(0) * std::cos(temp_meanTheta) +
+                                    P(1) * std::sin(temp_meanTheta)
+                          << " " << temp_meanTheta / Physics::deg2rad
+                          << " " << - P(0) * std::sin(temp_meanTheta) +
+                                      P(1) * std::cos(temp_meanTheta)
+                          << " " << R(2)
+                          << " " << P(2) << std::endl;
     }
 }
 

--- a/src/Algorithms/ParallelCyclotronTracker.h
+++ b/src/Algorithms/ParallelCyclotronTracker.h
@@ -22,6 +22,7 @@
 #include "AbsBeamline/ElementBase.h"
 #include <vector>
 #include <tuple>
+#include <memory>
 
 #include "Steppers/Steppers.h"
 
@@ -326,11 +327,11 @@ private:
     const size_t initialTotalNum_m;
 
     /// output coordinates at different azimuthal angles and one after every turn
-    std::vector<std::ofstream> outfTheta_m;
+    std::vector<std::unique_ptr<std::ofstream> > outfTheta_m;
     /// the different azimuthal angles for the outfTheta_m output files
     std::vector<double> azimuth_angle_m;
     ///@ open / close output coordinate files
-    void openFiles(std::string fn);
+    void openFiles(size_t numFiles, std::string fn);
     void closeFiles();
     ///@}
     /// output file for six dimensional phase space


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [iostream instances aren't movable in old...](https://gitlab.psi.ch/OPAL/src/merge_requests/73) |
> | **GitLab MR Number** | [73](https://gitlab.psi.ch/OPAL/src/merge_requests/73) |
> | **Date Originally Opened** | Wed, 3 Apr 2019 |
> | **Date Originally Merged** | Fri, 5 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

I used unique_ptr instead which works also for older versions of gcc.