### PR TITLE
Missed some getCoordTransformationTo. Fixing this

### DIFF
--- a/src/Algorithms/ParallelTTracker.cpp
+++ b/src/Algorithms/ParallelTTracker.cpp
@@ -161,7 +161,7 @@ ParallelTTracker::~ParallelTTracker() {
 void ParallelTTracker::visitBeamline(const Beamline &bl) {
     const FlaggedBeamline* fbl = static_cast<const FlaggedBeamline*>(&bl);
     if (fbl->getRelativeFlag()) {
-        OpalBeamline stash(fbl->getOrigin3D(), fbl->getCoordTransformationTo());
+        OpalBeamline stash(fbl->getOrigin3D(), fbl->getInitialDirection());
         stash.swap(itsOpalBeamline_m);
         fbl->iterate(*this, false);
         itsOpalBeamline_m.prepareSections();

--- a/src/Classic/Beamlines/TBeamline.h
+++ b/src/Classic/Beamlines/TBeamline.h
@@ -147,9 +147,8 @@ public:
 
     void setOrigin3D(const Vector_t& ori);
     Vector_t getOrigin3D() const;
-
-    void setCoordTransformationTo(const Quaternion& trafoTo);
-    Quaternion getCoordTransformationTo() const;
+    void setInitialDirection(const Quaternion& rot);
+    Quaternion getInitialDirection() const;
 
     void setRelativeFlag(bool flag);
     bool getRelativeFlag() const;
@@ -453,12 +452,12 @@ Vector_t TBeamline<T>::getOrigin3D() const {
 }
 
 template <class T> inline
-void TBeamline<T>::setCoordTransformationTo(const Quaternion& trafoTo) {
+void TBeamline<T>::setInitialDirection(const Quaternion& trafoTo) {
     itsCoordTrafoTo_m = trafoTo;
 }
 
 template <class T> inline
-Quaternion TBeamline<T>::getCoordTransformationTo() const {
+Quaternion TBeamline<T>::getInitialDirection() const {
     return itsCoordTrafoTo_m;
 }
 

--- a/src/Lines/Line.cpp
+++ b/src/Lines/Line.cpp
@@ -232,9 +232,9 @@ void Line::parse(Statement &stat) {
             Quaternion rotTheta(cos(0.5 * theta), 0, -sin(0.5 * theta), 0);
             Quaternion rotPhi(cos(0.5 * phi), -sin(0.5 * phi), 0, 0);
             Quaternion rotPsi(cos(0.5 * psi), 0, 0, -sin(0.5 * psi));
-            line->setCoordTransformationTo(rotPsi * rotPhi * rotTheta);
+            line->setInitialDirection(rotPsi * rotPhi * rotTheta);
         } else {
-            line->setCoordTransformationTo(Quaternion(1, 0, 0, 0));
+            line->setInitialDirection(Quaternion(1, 0, 0, 0));
             if (itsAttr[ORIENTATION]) {
                 throw OpalException("Line::parse","Parameter orientation is array of 3 values (theta, phi, psi);\n" +
                                     std::to_string(direction.size()) + " values provided");
@@ -256,7 +256,7 @@ void Line::parse(Statement &stat) {
         Quaternion rotPsi(cos(0.5 * psi), 0, 0, -sin(0.5 * psi));
 
         line->setOrigin3D(origin);
-        line->setCoordTransformationTo(rotPsi * rotPhi * rotTheta);
+        line->setInitialDirection(rotPsi * rotPhi * rotTheta);
 
         line->setRelativeFlag(!itsAttr[X].defaultUsed() ||
                               !itsAttr[Y].defaultUsed() ||


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Missed some getCoordTransformationTo. Fi...](https://gitlab.psi.ch/OPAL/src/merge_requests/74) |
> | **GitLab MR Number** | [74](https://gitlab.psi.ch/OPAL/src/merge_requests/74) |
> | **Date Originally Opened** | Thu, 4 Apr 2019 |
> | **Date Originally Merged** | Thu, 4 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Somehow I missed some of the occurances of `getCoordTransformation` when I replaced the name of the method with `getInitialDirection`. Now all are replaced.