### PR TITLE
Avoid duplication of member variables for location and momentum of the...

### DIFF
--- a/src/Algorithms/ParallelTTracker.h
+++ b/src/Algorithms/ParallelTTracker.h
@@ -201,9 +201,6 @@ private:
 
     OpalBeamline itsOpalBeamline_m;
 
-    Vector_t RefPartR_m;
-    Vector_t RefPartP_m;
-
     bool globalEOL_m;
 
     bool wakeStatus_m;
@@ -247,8 +244,6 @@ private:
     IpplTimings::TimerRef fieldEvaluationTimer_m ;
     IpplTimings::TimerRef BinRepartTimer_m;
     IpplTimings::TimerRef WakeFieldTimer_m;
-
-    CoordinateSystemTrafo referenceToLabCSTrafo_m;
 
     std::set<ParticleMatterInteractionHandler*> activeParticleMatterInteractionHandlers_m;
     bool particleMaterStatus_m;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Avoid duplication of member variables fo...](https://gitlab.psi.ch/OPAL/src/merge_requests/75) |
> | **GitLab MR Number** | [75](https://gitlab.psi.ch/OPAL/src/merge_requests/75) |
> | **Date Originally Opened** | Fri, 5 Apr 2019 |
> | **Date Originally Merged** | Sat, 6 Apr 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Avoid duplication of member variables for location and momentum of the reference particle and the transformation from the reference to lab coordinate system. Deleted the member variables in the ParallelTTracker and just using the ones in the PartBunch. This is a first step towards #287.