### PR TITLE
replace all tabs with 4 spaces

### DIFF
--- a/src/AbstractObjects/OpalData.cpp
+++ b/src/AbstractObjects/OpalData.cpp
@@ -458,27 +458,27 @@ energyEvolution_t::iterator OpalData::getLastEnergyData() {
 
 
 // Mesh_t* OpalData::getMesh() {
-// 	return p->mesh_m;
+//  return p->mesh_m;
 // }
 
 // FieldLayout_t* OpalData::getFieldLayout() {
-// 	return p->FL_m;
+//  return p->FL_m;
 // }
 
 // Layout_t* OpalData::getLayout() {
-// 	return p->PL_m;
+//  return p->PL_m;
 // }
 
 // void OpalData::setMesh(Mesh_t *mesh) {
-// 	p->mesh_m = mesh;
+//  p->mesh_m = mesh;
 // }
 
 // void OpalData::setFieldLayout(FieldLayout_t *fieldlayout) {
-// 	p->FL_m = fieldlayout;
+//  p->FL_m = fieldlayout;
 // }
 
 // void OpalData::setLayout(Layout_t *layout) {
-// 	p->PL_m = layout;
+//  p->PL_m = layout;
 // }
 
 void OpalData::setGlobalPhaseShift(double shift) {

--- a/src/Algorithms/CavityAutophaser.cpp
+++ b/src/Algorithms/CavityAutophaser.cpp
@@ -266,7 +266,7 @@ double CavityAutophaser::track(Vector_t R,
                                double t,
                                const double dt,
                                const double phase,
-			       std::ofstream *out) const {
+                               std::ofstream *out) const {
     const Vector_t &refP = initialP_m;
 
     RFCavity *rfc = static_cast<RFCavity *>(itsCavity_m.get());
@@ -278,7 +278,7 @@ double CavityAutophaser::track(Vector_t R,
                                                             dt,
                                                             itsReference_m.getQ(),
                                                             itsReference_m.getM() * 1e-6,
-							    out);
+                                                            out);
     rfc->setPhasem(initialPhase);
 
     double finalKineticEnergy = Util::getEnergy(Vector_t(0.0, 0.0, pe.first), itsReference_m.getM() * 1e-6);

--- a/src/Algorithms/CavityAutophaser.h
+++ b/src/Algorithms/CavityAutophaser.h
@@ -27,7 +27,7 @@ private:
                  double t,
                  const double dt,
                  const double phase,
-		 std::ofstream *out = NULL) const;
+                 std::ofstream *out = NULL) const;
     double getEnergyMeV(const Vector_t &P);
     double getMomentum(double kineticEnergyMeV);
 

--- a/src/Algorithms/Ctunes.cpp
+++ b/src/Algorithms/Ctunes.cpp
@@ -126,7 +126,7 @@ int TUNE_class::lombAnalysis(std::vector<double> &x, std::vector<double> &y, int
                 if(pairy[pairc] > 4.) {
                     memset(mess, '\0', sizeof(mess));
                     sprintf(mess, "%12.8f %8.2f %8.3f %d", pairx[pairc]*Norm, pairy[pairc], probi, i);
-		    *gmsg << "* " << mess << endl;
+                    *gmsg << "* " << mess << endl;
                 }
             }
             pairc++;
@@ -188,7 +188,7 @@ int TUNE_class::lombAnalysis(double *x, double *y, int Ndat, int nhis)
     if(datcnt > (q - p - 10)) {
         memset(mess, '\0', sizeof(mess));
         sprintf(mess, "Just found %d data points that are == 0!", datcnt);
-	*gmsg << "* " << mess << endl;
+        *gmsg << "* " << mess << endl;
         return(-1);
     }
 
@@ -205,7 +205,7 @@ int TUNE_class::lombAnalysis(double *x, double *y, int Ndat, int nhis)
     if(stat != 0) {
         memset(mess, '\0', sizeof(mess));
         sprintf(mess, "@C3ERROR: Lomb analysis failed!");
-	*gmsg << "* " << mess << endl;
+        *gmsg << "* " << mess << endl;
 
         delete la;
         la = NULL;
@@ -245,7 +245,7 @@ int TUNE_class::lombAnalysis(double *x, double *y, int Ndat, int nhis)
                     memset(mess, '\0', sizeof(mess));
                     sprintf(mess, "%12.8f %8.2f %8.3f %d", pairx[pairc], pairy[pairc],
                             probi, i);
-		    *gmsg << "* " << mess << endl;
+                    *gmsg << "* " << mess << endl;
                 }
             }
             pairc++;

--- a/src/Algorithms/ParallelSliceTracker.cpp
+++ b/src/Algorithms/ParallelSliceTracker.cpp
@@ -154,10 +154,10 @@ void ParallelSliceTracker::printRFPhases() {
 
         if (element->getType() == ElementBase::TRAVELINGWAVE) {
             phase = static_cast<TravelingWave *>(element.get())->getPhasem();
-	    frequency = static_cast<TravelingWave *>(element.get())->getFrequencym();
+            frequency = static_cast<TravelingWave *>(element.get())->getFrequencym();
         } else {
             phase = static_cast<RFCavity *>(element.get())->getPhasem();
-	    frequency = static_cast<RFCavity *>(element.get())->getFrequencym();
+            frequency = static_cast<RFCavity *>(element.get())->getFrequencym();
         }
 
         msg << (it == cl.begin()? "": "\n")
@@ -167,7 +167,7 @@ void ParallelSliceTracker::printRFPhases() {
     }
 
     msg << "-------------------------------------------------------------------------------------\n"
-	<< endl;
+        << endl;
 }
 
 void ParallelSliceTracker::applyEntranceFringe(double angle, double curve,

--- a/src/Algorithms/ParallelTTracker.cpp
+++ b/src/Algorithms/ParallelTTracker.cpp
@@ -1023,7 +1023,7 @@ void ParallelTTracker::writePhaseSpace(const long long step, bool psDump, bool s
     if (statDump) {
         std::vector<std::pair<std::string, unsigned int> > collimatorLosses;
         FieldList collimators = itsOpalBeamline_m.getElementByType(ElementBase::CCOLLIMATOR);
-	if (collimators.size() != 0) {
+        if (collimators.size() != 0) {
             for (FieldList::iterator it = collimators.begin(); it != collimators.end(); ++ it) {
                 FlexibleCollimator* coll = static_cast<FlexibleCollimator*>(it->getElement().get());
                 std::string name = coll->getName();
@@ -1044,7 +1044,7 @@ void ParallelTTracker::writePhaseSpace(const long long step, bool psDump, bool s
             for (size_t i = 0; i < collimatorLosses.size(); ++ i){
                 collimatorLosses[i].second = bareLosses[i];
             }
-	}
+        }
         // Write statistical data.
         itsDataSink_m->writeStatData(itsBunch_m, FDext, collimatorLosses);
 

--- a/src/Algorithms/bet/EnvelopeBunch.cpp
+++ b/src/Algorithms/bet/EnvelopeBunch.cpp
@@ -577,7 +577,7 @@ void EnvelopeBunch::setBinnedLShape(EnvelopeBunchShape shape, double z0, double 
         case bsRect:
 
             bunch_width = Physics::c * emission_time_s * slices_m[0]->p[SLI_beta];
-	    //            std::cout << "bunch_width = " << bunch_width << " SLI_beta= " << slices_m[0]->p[SLI_beta] << std::endl;
+//            std::cout << "bunch_width = " << bunch_width << " SLI_beta= " << slices_m[0]->p[SLI_beta] << std::endl;
             for(int i = 0; i < numMySlices_m; i++) {
                 slices_m[i]->p[SLI_z] = -(((numSlices_m - 1) - (mySliceStartOffset_m + i)) * bunch_width) / numSlices_m;
             }
@@ -634,10 +634,10 @@ void EnvelopeBunch::setBinnedLShape(EnvelopeBunchShape shape, double z0, double 
     /*
     for(unsigned int i = 0; i < bins_m.size(); i++) {
       if(bins_m[i].size() > 0) {
-	std::cout << Ippl::Comm->myNode() << ": Bin " << i << ": ";
-	for(unsigned int j = 0; j < bins_m[i].size(); j++)
-	  std::cout << " " << mySliceStartOffset_m + bins_m[i][j] << "(" << slices_m[j]->p[SLI_z] << ")";
-	std::cout << std::endl;
+    std::cout << Ippl::Comm->myNode() << ": Bin " << i << ": ";
+    for(unsigned int j = 0; j < bins_m[i].size(); j++)
+      std::cout << " " << mySliceStartOffset_m + bins_m[i][j] << "(" << slices_m[j]->p[SLI_z] << ")";
+    std::cout << std::endl;
       }
     }
     */

--- a/src/Algorithms/bet/error.C
+++ b/src/Algorithms/bet/error.C
@@ -29,18 +29,18 @@
 #include "error.h"
 #include "libprf/prf.h"
 
-static int 
+static int
   firstTime   = 1,
   reportLevel = 0,   // verbosity level
   nodeID      = 0;   // required to be MPI compatible
 
 static char
-  *fName = NULL; 
+  *fName = NULL;
 
 void initErrorMsg(int level,const char *fbase) {
-  stdprf ();	/* set standard functions */
-  extprf ();	/* set extended standard functions */
-  fltprf ();	/* set floating standard functions */
+  stdprf ();    /* set standard functions */
+  extprf ();    /* set extended standard functions */
+  fltprf ();    /* set floating standard functions */
 
   reportLevel = level;
 
@@ -60,7 +60,7 @@ void initErrorFilename(const char *fbase) {
     if (fName) {
       free(fName);
     }
-    
+
     fName = (char *) malloc(sizeof(char)*(strlen(fbase)+10));
     if (fName) {
 #ifdef USE_MPI
@@ -69,14 +69,14 @@ void initErrorFilename(const char *fbase) {
 #else
       sprintf(fName,"%s.msg",fbase);
 #endif
-      
+
       sprintf(cmd,"rm -f %s",fName);
       system(cmd);
       free(cmd);
       firstTime = 1;
     } else {
       fprintf(stderr,"ERROR in initErrorFilename: %s (%s)\n",
-	      "Insufficient memory to allocate filename",fbase);
+              "Insufficient memory to allocate filename",fbase);
     }
   }
 } /* initErrorFileName() */
@@ -86,15 +86,15 @@ void setReportLevel(int level) {
 }
 
 void writeError(ErrorMode m,ErrorType t,const char* fmt, ...) {
-  if ((m == errModeAll) || 
-      ((m == errModeMaster) && (nodeID == 0)) || 
+  if ((m == errModeAll) ||
+      ((m == errModeMaster) && (nodeID == 0)) ||
       ((m == errModeSlave)  && (nodeID  > 0))) {
 
     va_list ap;
     char    str[4096],mpiStr[20];
 
     va_start(ap,fmt);
-    
+
     switch (t) {
     case errMessage: sprf(str,"MSG:.. "); break;
     case errWarning: sprf(str,"WAR:.. "); break;
@@ -109,23 +109,23 @@ void writeError(ErrorMode m,ErrorType t,const char* fmt, ...) {
 
     sprfv(str, fmt, &ap);
     va_end(ap);
-    
+
     fprintf(stderr,"%s\n",str);
     fflush(stderr);
 
     if (fName) {
-      FILE *ofp = fopen(fName,(firstTime==1?"w":"a"));
-      
-      if (ofp) {
-	fprintf(ofp,"%s\n",str);
-	fclose(ofp);
-      } else if (firstTime == 1) {
-	int myerr = errno;
-	fprintf(stderr,
-		"writeError cannot open %s (%d)\n%s\n",
-		fName,myerr,strerror(myerr));
-      }
-      firstTime = 0;
+        FILE *ofp = fopen(fName,(firstTime==1?"w":"a"));
+
+        if (ofp) {
+            fprintf(ofp,"%s\n",str);
+            fclose(ofp);
+        } else if (firstTime == 1) {
+            int myerr = errno;
+            fprintf(stderr,
+                    "writeError cannot open %s (%d)\n%s\n",
+                    fName,myerr,strerror(myerr));
+        }
+        firstTime = 0;
     }
   }
   if (t == errFatal) {
@@ -138,23 +138,23 @@ void writeError(ErrorMode m,ErrorType t,const char* fmt, ...) {
 }
 
 void writeError(int level,ErrorMode m,ErrorType t,const char* fmt, ...) {
-  if ((m == errModeAll) || 
-      ((m == errModeMaster) && (nodeID == 0)) || 
+  if ((m == errModeAll) ||
+      ((m == errModeMaster) && (nodeID == 0)) ||
       ((m == errModeSlave)  && (nodeID  > 0))) {
 
     if ((level <= reportLevel) || (t == errFatal)) {
       va_list ap;
       char    str[4096],mpiStr[20];
-    
+
       va_start(ap,fmt);
-      
+
       switch (t) {
       case errMessage: sprf(str,"MSG:.. "); break;
       case errWarning: sprf(str,"WAR:.. "); break;
       case errGeneral: sprf(str,"ERR:.. "); break;
       case errFatal:   sprf(str,"FATAL: "); break;
       }
-      
+
 #ifdef USE_MPI
       sprintf(mpiStr,"%2d ",mpi_rank);
       sprf(str,mpiStr);
@@ -167,18 +167,18 @@ void writeError(int level,ErrorMode m,ErrorType t,const char* fmt, ...) {
       fflush(stderr);
 
       if (fName) {
-	FILE *ofp = fopen(fName,(firstTime==1?"w":"a"));
-	
-	if (ofp) {
-	  fprintf(ofp,"%s\n",str);
-	  fclose(ofp);
-	} else if (firstTime == 1) {
-	  int myerr = errno;
-	  fprintf(stderr,
-		  "writeError cannot open %s (%d)\n%s\n",
-		  fName,myerr,strerror(myerr));
-	}
-	firstTime = 0;
+          FILE *ofp = fopen(fName,(firstTime==1?"w":"a"));
+
+          if (ofp) {
+              fprintf(ofp,"%s\n",str);
+              fclose(ofp);
+          } else if (firstTime == 1) {
+              int myerr = errno;
+              fprintf(stderr,
+                      "writeError cannot open %s (%d)\n%s\n",
+                      fName,myerr,strerror(myerr));
+          }
+          firstTime = 0;
       }
     }
   }
@@ -190,4 +190,3 @@ void writeError(int level,ErrorMode m,ErrorType t,const char* fmt, ...) {
     exit(1);
   }
 }
-

--- a/src/Algorithms/bet/profile.cpp
+++ b/src/Algorithms/bet/profile.cpp
@@ -93,7 +93,7 @@ Profile::Profile(char *fname, double eps) {
     for(i = 0; i < n; i++) {
       int res = fscanf(f, "%lf %lf", &x[i], &y[i]);
       if (res !=0)
-	ERRORMSG("fscanf in profile.cpp has res!=0" << endl);
+          ERRORMSG("fscanf in profile.cpp has res!=0" << endl);
     }
     fclose(f);
 
@@ -295,4 +295,3 @@ double Profile::Labs() {
     return (((x == NULL) || (x[n-1] == x[0]) || (ym == 0.0)) ? 0.0 :
             fabs(qromb(f3, x[0], x[n-1]) / ym));
 }
-

--- a/src/BasicActions/Option.cpp
+++ b/src/BasicActions/Option.cpp
@@ -258,7 +258,7 @@ Option::Option():
                                                      "The frequency to dump grid "
                                                      "and particle data "
                                                      "(default: 10)", amrYtDumpFreq);
-    
+
     itsAttr[AMR_REGRID_FREQ] = Attributes::makeReal("AMR_REGRID_FREQ",
                                                     "The frequency to perform a regrid "
                                                     "in multi-bunch mode (default: 10)",
@@ -382,9 +382,9 @@ void Option::execute() {
     ///       not for the distributions
     if(itsAttr[SEED]) {
         seed = int(Attributes::getReal(itsAttr[SEED]));
-	if (seed == -1)
+        if (seed == -1)
             rangen.init55(time(0));
-	else
+        else
             rangen.init55(seed);
     }
 

--- a/src/Classic/AbsBeamline/Bend.cpp
+++ b/src/Classic/AbsBeamline/Bend.cpp
@@ -113,7 +113,7 @@ Bend::Bend(const Bend &right):
     sinEntranceAngle_m(right.sinEntranceAngle_m),
     tanEntranceAngle_m(right.tanEntranceAngle_m),
     tanExitAngle_m(right.tanExitAngle_m),
-	nSlices_m(right.nSlices_m){
+    nSlices_m(right.nSlices_m){
 
     setElType(isDipole);
 
@@ -154,7 +154,7 @@ Bend::Bend(const std::string &name):
     sinEntranceAngle_m(0.0),
     tanEntranceAngle_m(0.0),
     tanExitAngle_m(0.0),
-	nSlices_m(1){
+    nSlices_m(1){
 
     setElType(isDipole);
 
@@ -475,11 +475,11 @@ Vector_t Bend::calcEntranceFringeField(const Vector_t &R,
 
 
         // B(1) = (engeFunc *
-	//  (1.0 - 0.5 * engeFuncSecDerivNorm * pow(Rprime(1), 2.0)));
+        //  (1.0 - 0.5 * engeFuncSecDerivNorm * pow(Rprime(1), 2.0)));
 
-	B(1) = (engeFunc - 0.5 * engeFuncSecDeriv * pow(Rprime(1), 2.0));
+        B(1) = (engeFunc - 0.5 * engeFuncSecDeriv * pow(Rprime(1), 2.0));
 
-	B(2) = engeFuncDeriv * Rprime(1);
+        B(2) = engeFuncDeriv * Rprime(1);
     }
 
     return toEntranceRegion.rotateFrom(B);
@@ -514,7 +514,7 @@ Vector_t Bend::calcExitFringeField(const Vector_t &R,
 
         //B(1) = (engeFunc *
         //        (1.0 - 0.5 * engeFuncSecDerivNorm * pow(Rprime(1), 2.0)));
-	B(1) = (engeFunc - 0.5 * engeFuncSecDeriv * pow(Rprime(1), 2.0));
+        B(1) = (engeFunc - 0.5 * engeFuncSecDeriv * pow(Rprime(1), 2.0));
 
         B(2) = engeFuncDeriv * Rprime(1);
     }
@@ -859,7 +859,7 @@ bool Bend::findIdealBendParameters(double chordLength) {
         }
         designRadius_m = chordLength / (2.0 * std::sin(angle_m / 2.0));
 
-	fieldAmplitude_m = ((refCharge / std::abs(refCharge)) *
+        fieldAmplitude_m = ((refCharge / std::abs(refCharge)) *
                             refBetaGamma * refMass /
                             (Physics::c * designRadius_m));
         reinitialize = true;

--- a/src/Classic/AbsBeamline/CyclotronValley.cpp
+++ b/src/Classic/AbsBeamline/CyclotronValley.cpp
@@ -118,7 +118,7 @@ bool CyclotronValley::applyToReferenceParticle(const Vector_t &tmpR, const Vecto
     Vector_t  tmpE(0.0, 0.0, 0.0), tmpB(0.0, 0.0, 0.0);
 
     if(!fieldmap_m->getFieldstrength(tmpR, tmpE, tmpB)) {
-	B +=scale_m * tmpB;
+        B +=scale_m * tmpB;
         return false;
     }
     return true;

--- a/src/Classic/AbsBeamline/MultipoleT.h
+++ b/src/Classic/AbsBeamline/MultipoleT.h
@@ -32,7 +32,7 @@
 
 /** ---------------------------------------------------------------------
   *
-  * MultipoleT defines a straight or curved combined function magnet (up 
+  * MultipoleT defines a straight or curved combined function magnet (up
   * to arbitrary multipole component) with Fringe Fields
   *
   * ---------------------------------------------------------------------
@@ -47,29 +47,29 @@
   *     ...  @f] \n
   *     (x,z,s) -> Frenet-Serret local coordinates along the magnet \n
   *     z -> vertical component \n
-  *     assume mid-plane symmetry \n 
+  *     assume mid-plane symmetry \n
   *     set field on mid-plane -> @f$ B_z = f_0(x,s) = T(x) \cdot S(s) @f$ \n
   *     T(x) -> transverse profile; this is a polynomial describing
   *             the field expansion on the mid-plane inside the magnet
   *             (not in the fringe field);
-  *             1st term is the dipole strength, 2nd term is the 
+  *             1st term is the dipole strength, 2nd term is the
   *             quadrupole gradient * x, etc. \n
   *          -> when setting the magnet, one gives the multipole
-  *             coefficients of this polynomial (i.e. dipole strength,  
+  *             coefficients of this polynomial (i.e. dipole strength,
   *             quadrupole gradient, etc.) \n
   * \n
   * ------------- example ----------------------------------------------- \n
-  *     Setting a combined function magnet with dipole, quadrupole and 
+  *     Setting a combined function magnet with dipole, quadrupole and
   *     sextupole components: \n
   *     @f$ T(x) = B_0 + B_1 \cdot x + B_2 \cdot x^2 @f$\n
   *     user gives @f$ B_0, B_1, B_2 @f$ \n
   * ------------- example end ------------------------------------------- \n
   * \n
   *     S(s) -> fringe field \n
-  *     recursion -> @f$ f_n (x,s) = (-1)^n \cdot \sum_{i=0}^{n} C_n^i 
+  *     recursion -> @f$ f_n (x,s) = (-1)^n \cdot \sum_{i=0}^{n} C_n^i
   *     \cdot T^{(2i)} \cdot S^{(2n-2i)} @f$ \n
   *     for curved magnets the above recursion is more complicated \n
-  *     @f$ C_n^i @f$ -> binomial coeff; 
+  *     @f$ C_n^i @f$ -> binomial coeff;
   *     @f$ T^{(n)} @f$ -> n-th derivative
   *
   * ---------------------------------------------------------------------
@@ -87,14 +87,14 @@
 #include <vector>
 
 class MultipoleT: public Component {
-public: 
+public:
     /** Constructor
      *  \param name -> User-defined name
      */
     explicit MultipoleT(const std::string &name);
     /** Copy constructor */
     MultipoleT(const MultipoleT &right);
-    /** Destructor */ 
+    /** Destructor */
     ~MultipoleT();
     /** Inheritable copy constructor */
     ElementBase* clone() const override;
@@ -166,7 +166,7 @@ public:
     /** Get the maximum order in the given transverse profile */
     std::size_t getTransMaxOrder() const;
     /** Set the maximum order in the given transverse profile
-     *  \param transMaxOrder -> Highest power of x in field expansion 
+     *  \param transMaxOrder -> Highest power of x in field expansion
      */
     void setTransMaxOrder(std::size_t transMaxOrder);
     /** Set transverse profile T(x)
@@ -183,15 +183,15 @@ public:
     std::vector<double> getTransProfile() const;
     /** Set fringe field model \n
      *  Tanh model used here \n
-     *  @f[ 1/2 * \left [tanh \left( \frac{s + s_0}{\lambda_{left}} \right) 
-     *  - tanh \left( \frac{s - s_0}{\lambda_{right}} \right) \right] @f] 
+     *  @f[ 1/2 * \left [tanh \left( \frac{s + s_0}{\lambda_{left}} \right)
+     *  - tanh \left( \frac{s - s_0}{\lambda_{right}} \right) \right] @f]
      *  \param s0 -> Centre field length
      *  \param \lambda_{left} -> Left end field length
      *  \param \lambda_{right} -> Right end field length
      */
     bool setFringeField(double s0, double lambda_left, double lambda_right);
     /** Return vector of 2 doubles
-      * [left fringe length, right fringelength]  
+      * [left fringe length, right fringelength]
       */
     std::vector<double> getFringeLength() const;
     /** Set the bending angle of the magnet */
@@ -204,7 +204,7 @@ public:
     void setEntranceAngle(double entranceAngle);
     /** Get the entrance angle */
     double getEntranceAngle() const;
-    /** Get the bending radius \n 
+    /** Get the bending radius \n
       * Not used, when needed radius is found from length_m / angle_m
       */
     double getBendRadius() const;
@@ -260,7 +260,7 @@ private:
     std::vector<polynomial::RecursionRelationTwo> recursion_VarRadius_m;
     std::vector<polynomial::RecursionRelation> recursion_ConstRadius_m;
     /** Highest power in given mid-plane field */
-    std::size_t transMaxOrder_m = 0; 
+    std::size_t transMaxOrder_m = 0;
     /** List of transverse profile coefficients */
     std::vector<double> transProfile_m;
     /** Geometry */
@@ -367,7 +367,7 @@ inline
     double MultipoleT::getEntranceAngle() const {
         return entranceAngle_m;
 }
-inline 
+inline
     double MultipoleT::getTransProfile(int n) const {
         return transProfile_m[n];
 }
@@ -375,7 +375,7 @@ inline
     std::vector<double> MultipoleT::getTransProfile() const {
         return transProfile_m;
 }
-inline 
+inline
     double MultipoleT::getDipoleConstant() const {
          return transProfile_m[0];
 }
@@ -397,16 +397,16 @@ inline
     std::size_t MultipoleT::getTransMaxOrder() const {
         return transMaxOrder_m;
 }
-inline 
+inline
     void MultipoleT::setTransMaxOrder(std::size_t transMaxOrder) {
         transMaxOrder_m = transMaxOrder;
-	transProfile_m.resize(transMaxOrder + 1, 0.);
+        transProfile_m.resize(transMaxOrder + 1, 0.);
 }
 inline
     double MultipoleT::getRotation() const {
          return rotation_m;
 }
-inline 
+inline
     void MultipoleT::setRotation(double rot) {
          rotation_m = rot;
 }

--- a/src/Classic/AbsBeamline/Offset.cpp
+++ b/src/Classic/AbsBeamline/Offset.cpp
@@ -208,11 +208,11 @@ bool operator==(const Offset& off1, const Offset& off2) {
     }
     for (int i = 0; i < 3; ++i) {
       if ( (fabs(off1.getEndPosition()(i)-off2.getEndPosition()(i)) > tol) ||
-	   (fabs(off1.getEndDirection()(i)-off2.getEndDirection()(i)) > tol))
+           (fabs(off1.getEndDirection()(i)-off2.getEndDirection()(i)) > tol))
             return false;
     }
     if ( (!off1.isGeometryAllocated() && off2.isGeometryAllocated()) ||
-	 (!off2.isGeometryAllocated() && off1.isGeometryAllocated()))
+         (!off2.isGeometryAllocated() && off1.isGeometryAllocated()))
         return false;
     Euclid3D transform1 = off1.getGeometry().getTotalTransform();
     Euclid3D transform2 = off2.getGeometry().getTotalTransform();

--- a/src/Classic/AbsBeamline/RFCavity.cpp
+++ b/src/Classic/AbsBeamline/RFCavity.cpp
@@ -794,7 +794,7 @@ pair<double, double> RFCavity::trackOnAxisParticle(const double &p0,
                                                    const double &dt,
                                                    const double &q,
                                                    const double &mass,
-						   std::ofstream *out) {
+                                                   std::ofstream *out) {
     Vector_t p(0, 0, p0);
     double t = t0;
     BorisPusher integrator(*RefPartBunch_m->getReference());
@@ -807,8 +807,8 @@ pair<double, double> RFCavity::trackOnAxisParticle(const double &p0,
     Vector_t Ef(0.0), Bf(0.0);
 
     if (out) *out << std::setw(18) << z[2]
-		  << std::setw(18) << Util::getEnergy(p, mass)
-		  << std::endl;
+                  << std::setw(18) << Util::getEnergy(p, mass)
+                  << std::endl;
     while(z(2) + dz < zend && z(2) + dz > zbegin) {
         z /= cdt;
         integrator.push(z, p, dt);
@@ -827,9 +827,9 @@ pair<double, double> RFCavity::trackOnAxisParticle(const double &p0,
         z *= cdt;
         t += dt;
 
-	if (out) *out << std::setw(18) << z[2]
-		      << std::setw(18) << Util::getEnergy(p, mass)
-		      << std::endl;
+        if (out) *out << std::setw(18) << z[2]
+                      << std::setw(18) << Util::getEnergy(p, mass)
+                      << std::endl;
     }
 
     const double beta = sqrt(1. - 1 / (dot(p, p) + 1.));

--- a/src/Classic/AbsBeamline/RFCavity.h
+++ b/src/Classic/AbsBeamline/RFCavity.h
@@ -104,7 +104,7 @@ public:
                                                           const double & dt,
                                                           const double & q,
                                                           const double & mass,
-							  std::ofstream *out = NULL);
+                                                          std::ofstream *out = NULL);
 
     virtual void addKR(int i, double t, Vector_t &K) override;
 

--- a/src/Classic/AbsBeamline/TravelingWave.cpp
+++ b/src/Classic/AbsBeamline/TravelingWave.cpp
@@ -578,11 +578,11 @@ double TravelingWave::getAutoPhaseEstimate(const double &E0, const double &t0, c
 }
 
 std::pair<double, double> TravelingWave::trackOnAxisParticle(const double &p0,
-							     const double &t0,
-							     const double &dt,
-							     const double &q,
-							     const double &mass,
-							     std::ofstream *out) {
+                                                             const double &t0,
+                                                             const double &dt,
+                                                             const double &q,
+                                                             const double &mass,
+                                                             std::ofstream *out) {
     double phase = frequency_m * t0 + phase_m;
     double p = p0;
     double t = t0;
@@ -611,8 +611,8 @@ std::pair<double, double> TravelingWave::trackOnAxisParticle(const double &p0,
     delete[] onAxisField;
 
     if (out) *out << std::setw(18) << z
-		  << std::setw(18) << Util::getEnergy(p, mass)
-		  << std::endl;
+                  << std::setw(18) << Util::getEnergy(p, mass)
+                  << std::endl;
     double dz = 0.5 * p / sqrt(1.0 + p * p) * cdt;
     while(z + dz < startCoreField_m + zbegin) {
         z += dz;
@@ -647,9 +647,9 @@ std::pair<double, double> TravelingWave::trackOnAxisParticle(const double &p0,
         phase2 += dphi;
         t += dt;
 
-	if (out) *out << std::setw(18) << z
-		      << std::setw(18) << Util::getEnergy(p, mass)
-		      << std::endl;
+        if (out) *out << std::setw(18) << z
+                      << std::setw(18) << Util::getEnergy(p, mass)
+                      << std::endl;
     }
     phase = phase - phaseCore1_m + phaseExit_m;
     while(z + dz < startExitField_m + 0.5 * PeriodLength_m + zbegin) {

--- a/src/Classic/Algebra/ComplexEigen.cpp
+++ b/src/Classic/Algebra/ComplexEigen.cpp
@@ -171,9 +171,9 @@ next_row:
         j = ++low;
 
         // Restart search for next column.
-	/*
+        /*
         Die Abbruchbedingung in der Methode balance auf Zeile 176 der Datei /scratch2/amas/l_felsimsvn/src/opal/classic/5.0/src/Algebra/ComplexEigen.cpp
-        sollte von 
+        sollte von
          if(j = upp) break;
         auf
          if(j >= upp) break;
@@ -184,15 +184,15 @@ next_row:
 
          Matrix<double> m(2,2,0.0);
 
-         m[0][0]=1;  
+         m[0][0]=1;
          m[1][1]=3;
 
          DoubleEigen de(m,true);
 
-         Dies ist zwar ein bisschen ein akademischer Fall, war aber ausgerechnet mein erstes Testbeispiel. 
+         Dies ist zwar ein bisschen ein akademischer Fall, war aber ausgerechnet mein erstes Testbeispiel.
          Die vorgeschlagene Änderung ist performancemässig gleichwertig und sollte keine negativen Seiteneffekte haben.
 
-	*/
+        */
 next_column:
         if(j >= upp) break;
     }
@@ -573,7 +573,7 @@ int ComplexEigen::hqr2(Matrix<complex<double> > &h, int low,
     for(ssize_t en = upp + 1; en-- > low;) {
         ssize_t its = 0;
 
-	ssize_t l = en;
+        ssize_t l = en;
         // Look for singlengle small sub-diagonal element.
         while(true) {
             for(; l > low; l--) {

--- a/src/Classic/Algorithms/PartBunch.cpp
+++ b/src/Classic/Algorithms/PartBunch.cpp
@@ -200,7 +200,7 @@ void PartBunch::computeSelfFields(int binNumber) {
         int mz2 = (int)nr_m[2] / 2;
 
         for (int i=0; i<mx; i++ )
-	    *gmsg << "Bin " << binNumber
+            *gmsg << "Bin " << binNumber
                   << ", Self Field along x axis E = " << eg_m[i][my2][mz2]
                   << ", Pot = " << rho_m[i][my2][mz2]  << endl;
 
@@ -328,7 +328,7 @@ void PartBunch::computeSelfFields(int binNumber) {
         //int mz2 = (int)nr_m[2] / 2;
 
         for (int i=0; i<mx; i++ )
-	    *gmsg << "Bin " << binNumber
+            *gmsg << "Bin " << binNumber
                   << ", Image Field along x axis E = " << eg_m[i][my2][mz2]
                   << ", Pot = " << rho_m[i][my2][mz2]  << endl;
 
@@ -707,7 +707,7 @@ void PartBunch::computeSelfFields_cycl(double gamma) {
         /// retrive coefficient: -1/(eps)
         rho_m *= getCouplingConstant();
 
-	// If debug flag is set, dump scalar field (potential 'phi') into file under ./data/
+        // If debug flag is set, dump scalar field (potential 'phi') into file under ./data/
 #ifdef DBG_SCALARFIELD
         INFOMSG("*** START DUMPING SCALAR FIELD ***" << endl);
 
@@ -897,7 +897,7 @@ void PartBunch::computeSelfFields_cycl(int bin) {
         /// retrive coefficient: -1/(eps)
         rho_m *= getCouplingConstant();
 
-	// If debug flag is set, dump scalar field (potential 'phi') into file under ./data/
+        // If debug flag is set, dump scalar field (potential 'phi') into file under ./data/
 #ifdef DBG_SCALARFIELD
         INFOMSG("*** START DUMPING SCALAR FIELD ***" << endl);
 
@@ -939,7 +939,7 @@ void PartBunch::computeSelfFields_cycl(int bin) {
         int mz2 = (int)nr_m[2] / 2;
 
         for (int i=0; i<mx; i++ )
-	    *gmsg << "Bin " << bin
+            *gmsg << "Bin " << bin
                   << ", Field along x axis Ex = " << eg_m[i][my2][mz2]
                   << ", Pot = " << rho_m[i][my2][mz2]  << endl;
 

--- a/src/Classic/Algorithms/PartBunchBase.hpp
+++ b/src/Classic/Algorithms/PartBunchBase.hpp
@@ -421,7 +421,7 @@ void PartBunchBase<T, Dim>::calcGammas_cycl() {
     for(unsigned int n = 0; n < getLocalNum(); n++) {
         if ( this->Bin[n] > -1 ) {
             bingamma_m[this->Bin[n]] += sqrt(1.0 + dot(this->P[n], this->P[n]));
-	}
+        }
     }
 
     allreduce(*bingamma_m.get(), emittedBins, std::plus<double>());
@@ -934,7 +934,7 @@ void PartBunchBase<T, Dim>::getLocalBounds(Vector_t &rmin, Vector_t &rmax) {
         double maxValue = 1e8;
         rmin = Vector_t(maxValue, maxValue, maxValue);
         rmax = Vector_t(-maxValue, -maxValue, -maxValue);
-	return;
+        return;
     }
 
     rmin = R[0];
@@ -942,7 +942,7 @@ void PartBunchBase<T, Dim>::getLocalBounds(Vector_t &rmin, Vector_t &rmax) {
     for (size_t i = 1; i < localNum; ++ i) {
         for (unsigned short d = 0; d < 3u; ++ d) {
             if (rmin(d) > R[i](d)) rmin(d) = R[i](d);
-	    else if (rmax(d) < R[i](d)) rmax(d) = R[i](d);
+            else if (rmax(d) < R[i](d)) rmax(d) = R[i](d);
         }
     }
 }
@@ -1098,8 +1098,8 @@ double PartBunchBase<T, Dim>::get_sPos() {
             }
         }
         reduce(z, z, OpAddAssign());
-	reduce(numPrimBeamParts, numPrimBeamParts, OpAddAssign());
-	if(numPrimBeamParts != 0)
+        reduce(numPrimBeamParts, numPrimBeamParts, OpAddAssign());
+        if(numPrimBeamParts != 0)
             z = z / numPrimBeamParts;
         return z;
     } else {

--- a/src/Classic/BeamlineCore/CyclotronValleyRep.cpp
+++ b/src/Classic/BeamlineCore/CyclotronValleyRep.cpp
@@ -39,7 +39,7 @@ namespace {
             &CyclotronValleyRep::getElementLength,
             &CyclotronValleyRep::setElementLength
         },
-	{ 0, 0, 0 }
+        { 0, 0, 0 }
     };
 }
 

--- a/src/Classic/BeamlineCore/DegraderRep.cpp
+++ b/src/Classic/BeamlineCore/DegraderRep.cpp
@@ -39,7 +39,7 @@ namespace {
             &DegraderRep::getElementLength,
             &DegraderRep::setElementLength
         },
-	{ 0, 0, 0 }
+        { 0, 0, 0 }
     };
 }
 

--- a/src/Classic/BeamlineCore/ParallelPlateRep.cpp
+++ b/src/Classic/BeamlineCore/ParallelPlateRep.cpp
@@ -55,7 +55,7 @@ namespace {
             &ParallelPlateRep::getPhase,
             &ParallelPlateRep::setPhase
         },
-	{ 0, 0, 0 }
+        { 0, 0, 0 }
     };
 }
 

--- a/src/Classic/Fields/Fieldmap.cpp
+++ b/src/Classic/Fields/Fieldmap.cpp
@@ -361,22 +361,22 @@ MapType Fieldmap::readHeader(std::string Filename) {
 #endif
         char name[20];
         h5_size_t len_name = sizeof(name);
-	h5_prop_t props = H5CreateFileProp ();
+        h5_prop_t props = H5CreateFileProp ();
         MPI_Comm comm = Ippl::getComm();
         h5err = H5SetPropFileMPIOCollective (props, &comm);
         assert (h5err != H5_ERR);
         h5_file_t file = H5OpenFile (Filename.c_str(), H5_O_RDONLY, props);
-	assert (file != (h5_file_t)H5_ERR);
-	H5CloseProp (props);
+        assert (file != (h5_file_t)H5_ERR);
+        H5CloseProp (props);
 
-	h5err = H5SetStep(file, 0);
+        h5err = H5SetStep(file, 0);
         assert (h5err != H5_ERR);
 
-	h5_int64_t num_fields = H5BlockGetNumFields(file);
+        h5_int64_t num_fields = H5BlockGetNumFields(file);
         assert (num_fields != H5_ERR);
-	MapType maptype = UNKNOWN;
+        MapType maptype = UNKNOWN;
 
-	for(h5_ssize_t i = 0; i < num_fields; ++ i) {
+        for(h5_ssize_t i = 0; i < num_fields; ++ i) {
             h5err = H5BlockGetFieldInfo(
                 file, (h5_size_t)i, name, len_name, NULL, NULL, NULL, NULL);
             assert (h5err != H5_ERR);

--- a/src/Classic/Fields/Fieldmap.hpp
+++ b/src/Classic/Fields/Fieldmap.hpp
@@ -29,7 +29,7 @@ bool Fieldmap::interpreteLine(std::ifstream & in, T & value, const bool & file_l
             missingValuesWarning();
             return false;
         }
-	std::string expecting(boost::typeindex::type_id<T>().pretty_name());
+        std::string expecting(boost::typeindex::type_id<T>().pretty_name());
         interpreteWarning((interpreter.rdstate() ^ std::ios_base::eofbit), read_all, expecting, buffer);
     }
     return (!(interpreter.rdstate() ^ std::ios_base::eofbit) && read_all);   // eof should not be an error but if not eof
@@ -59,8 +59,8 @@ bool Fieldmap::interpreteLine(std::ifstream & in, S & value1, T & value2, const 
             missingValuesWarning();
             return false;
         }
-	std::string expecting(boost::typeindex::type_id<S>().pretty_name());
-	expecting += std::string(" ") + boost::typeindex::type_id<T>().pretty_name();
+        std::string expecting(boost::typeindex::type_id<S>().pretty_name());
+        expecting += std::string(" ") + boost::typeindex::type_id<T>().pretty_name();
         interpreteWarning((interpreter.rdstate() ^ std::ios_base::eofbit), read_all, expecting, buffer);
     }
     return (!(interpreter.rdstate() ^ std::ios_base::eofbit) && read_all);   // eof should not be an error but if not eof
@@ -92,9 +92,9 @@ bool Fieldmap::interpreteLine(std::ifstream & in, S & value1, T & value2, U & va
             missingValuesWarning();
             return false;
         }
-	std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<T>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<U>().pretty_name());
+        std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<T>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<U>().pretty_name());
         interpreteWarning((interpreter.rdstate() ^ std::ios_base::eofbit), read_all, expecting, buffer);
     }
     return (!(interpreter.rdstate() ^ std::ios_base::eofbit) && read_all);   // eof should not be an error but if not eof
@@ -128,10 +128,10 @@ bool Fieldmap::interpreteLine(std::ifstream & in, S & value1, T & value2, U & va
             missingValuesWarning();
             return false;
         }
-	std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<T>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<U>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<V>().pretty_name());
+        std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<T>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<U>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<V>().pretty_name());
         interpreteWarning((interpreter.rdstate() ^ std::ios_base::eofbit), read_all, expecting, buffer);
     }
     return (!(interpreter.rdstate() ^ std::ios_base::eofbit) && read_all);   // eof should not be an error but if not eof
@@ -169,12 +169,12 @@ bool Fieldmap::interpreteLine(std::ifstream & in, S & value1, S & value2, S & va
             missingValuesWarning();
             return false;
         }
-	std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
-			      boost::typeindex::type_id<S>().pretty_name());
+        std::string expecting(boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<S>().pretty_name() + std::string(" ") +
+                              boost::typeindex::type_id<S>().pretty_name());
         interpreteWarning((interpreter.rdstate() ^ std::ios_base::eofbit), read_all, expecting, buffer);
     }
     return (!(interpreter.rdstate() ^ std::ios_base::eofbit) && read_all);   // eof should not be an error but if not eof

--- a/src/Classic/Solvers/CSRIGFWakeFunction.cpp
+++ b/src/Classic/Solvers/CSRIGFWakeFunction.cpp
@@ -86,8 +86,8 @@ void CSRIGFWakeFunction::apply(PartBunchBase<double, 3> *bunch) {
         if(print_criterion) {
             static unsigned int file_number = 0;
             if(counter == 0) file_number = 0;
-	    double spos = bunch->get_sPos();
-	    if (Ippl::myNode() == 0) {
+            double spos = bunch->get_sPos();
+            if (Ippl::myNode() == 0) {
                 std::stringstream filename_str;
                 filename_str << "data/" << bendName_m << "-CSRWake" << std::setw(5) << std::setfill('0') << file_number << ".txt";
                 std::ofstream csr(filename_str.str().c_str());
@@ -99,7 +99,7 @@ void CSRIGFWakeFunction::apply(PartBunchBase<double, 3> *bunch) {
                 }
                 csr.close();
                 msg << "** wrote " << filename_str.str() << endl;
-	    }
+            }
             ++ file_number;
         }
         ++ counter;

--- a/src/Classic/Solvers/CSRWakeFunction.cpp
+++ b/src/Classic/Solvers/CSRWakeFunction.cpp
@@ -89,7 +89,7 @@ void CSRWakeFunction::apply(PartBunchBase<double, 3> *bunch) {
         if(print_criterion) {
             static unsigned int file_number = 0;
             if(counter == 0) file_number = 0;
-	    if (Ippl::myNode() == 0) {
+            if (Ippl::myNode() == 0) {
                 std::stringstream filename_str;
                 filename_str << "data/" << bendName_m << "-CSRWake" << std::setw(5) << std::setfill('0') << file_number << ".txt";
 
@@ -104,7 +104,7 @@ void CSRWakeFunction::apply(PartBunchBase<double, 3> *bunch) {
                 }
                 csr.close();
                 msg << "** wrote " << filename_str.str() << endl;
-	    }
+            }
             ++ file_number;
         }
         ++ counter;

--- a/src/Classic/Structure/LossDataSink.cpp
+++ b/src/Classic/Structure/LossDataSink.cpp
@@ -83,7 +83,7 @@
         throw GeneralClassicException(std::string(__func__), ss.str()); \
     }\
 }
-    
+
 #define OPEN_FILE( fname, mode, props ) {        \
     H5file_m = H5OpenFile (fname, mode, props); \
     if(H5file_m == (h5_file_t)H5_ERR) { \
@@ -222,7 +222,7 @@ void LossDataSink::addParticle(const Vector_t &x,const  Vector_t &p, const size_
 
 // For ring type simulation, dump the time and turn number
 void LossDataSink::addParticle(const Vector_t &x, const Vector_t &p, const size_t id,
-			       const double time, const size_t turn) {
+                               const double time, const size_t turn) {
     addParticle(x, p, id);
     turn_m.push_back(turn);
     time_m.push_back(time);
@@ -238,7 +238,7 @@ void LossDataSink::save(unsigned int numSets) {
         if (!Options::enableHDF5) return;
 
         fn_m = element_m + std::string(".h5");
-	INFOMSG(level2 << "Save " << fn_m << endl);
+        INFOMSG(level2 << "Save " << fn_m << endl);
         if (Options::openMode == Options::WRITE || !fs::exists(fn_m)) {
             openH5();
             writeHeaderH5();
@@ -252,22 +252,22 @@ void LossDataSink::save(unsigned int numSets) {
         for (unsigned int i = 0; i < numSets; ++ i) {
             saveH5(i);
         }
-	CLOSE_FILE ();
-	H5file_m = 0;
+        CLOSE_FILE ();
+        H5file_m = 0;
     }
     else {
         fn_m = element_m + std::string(".loss");
         INFOMSG(level2 << "Save " << fn_m << endl);
-	if (Options::openMode == Options::WRITE || !fs::exists(fn_m)) {
-	    appendASCII();
+        if (Options::openMode == Options::WRITE || !fs::exists(fn_m)) {
+            appendASCII();
         } else {
-	    openASCII();
+            openASCII();
         }
         writeHeaderASCII();
         saveASCII();
         closeASCII();
     }
-        Ippl::Comm->barrier();
+    Ippl::Comm->barrier();
 
     x_m.clear();
     y_m.clear();
@@ -356,7 +356,7 @@ void LossDataSink::saveH5(unsigned int setIdx) {
     if (hasTimeAttribute()) {
         WRITE_DATA_FLOAT64 ("time", &time_m[startIdx]);
         larray.assign (turn_m.begin() + startIdx, turn_m.end() );
-	WRITE_DATA_INT64 ("turn", &larray[0]);
+        WRITE_DATA_INT64 ("turn", &larray[0]);
     }
 
     ++ H5call_m;

--- a/src/Distribution/Distribution.h
+++ b/src/Distribution/Distribution.h
@@ -252,7 +252,7 @@ public:
     void createBoundaryGeometry(PartBunchBase<double, 3> *p, BoundaryGeometry &bg);
     void createOpalCycl(PartBunchBase<double, 3> *beam,
                         size_t numberOfParticles,
-			double current, const Beamline &bl);
+                        double current, const Beamline &bl);
     void createOpalE(Beam *beam,
                      std::vector<Distribution *> addedDistributions,
                      EnvelopeBunch *envelopeBunch,

--- a/src/Distribution/SigmaGenerator.h
+++ b/src/Distribution/SigmaGenerator.h
@@ -72,12 +72,12 @@ public:
     typedef Size_type size_type;
     /// Type for storing maps
     typedef boost::numeric::ublas::matrix<value_type> matrix_type;
-    
+
     typedef std::complex<value_type> complex_t;
-    
+
     /// Type for storing complex matrices
     typedef boost::numeric::ublas::matrix<complex_t> cmatrix_type;
-    
+
     /// Type for storing the sparse maps
     typedef boost::numeric::ublas::compressed_matrix<complex_t,
                                                      boost::numeric::ublas::row_major
@@ -130,14 +130,14 @@ public:
      */
     bool match(value_type accuracy, size_type maxit, size_type maxitOrbit,
                Cyclotron* cycl, value_type denergy, value_type rguess, bool harmonic, bool full);
-    
+
     /*!
      * Eigenvalue / eigenvector solver
      * @param Mturn is a 6x6 dimensional one turn transfer matrix
      * @param R is the 6x6 dimensional transformation matrix (gets computed)
      */
     void eigsolve_m(const matrix_type& Mturn, sparse_matrix_type& R);
-    
+
     /*!
      * @param R is the 6x6 dimensional transformation matrix
      * @param invR is the 6x6 dimensional inverse transformation (gets computed)
@@ -148,7 +148,7 @@ public:
 
     /// Block diagonalizes the symplex part of the one turn transfer matrix
     /*! It computes the transformation matrix <b>R</b> and its inverse <b>invR</b>.
-     * 
+     *
      * @param Mturn is a 6x6 dimensional one turn transfer matrix
      * @param R is the 6x6 dimensional transformation matrix (gets computed)
      * @param invR is the 6x6 dimensional inverse transformation (gets computed)
@@ -174,11 +174,11 @@ public:
 
     /// Returns the emittances (ex,ey,ez) in \f$ \pi\ mm\ mrad \f$ for which the code converged (since the whole simulation is done on normalized emittances)
     std::array<value_type,3> getEmittances() const;
-    
+
     const double& getInjectionRadius() const {
         return rinit_m;
     }
-    
+
     const double& getInjectionMomentum() const {
         return prinit_m;
     }
@@ -216,10 +216,10 @@ public:
     size_type nSectors_m;
     /// Number of integration steps per sector (--> also: number of maps per sector)
     size_type nStepsPerSector_m;
-    
+
     /// Number of integration steps in total
     size_type nSteps_m;
-    
+
     /// Error of computation
     value_type error_m;
 
@@ -228,7 +228,7 @@ public:
 
     /// Decides for writing output (default: true)
     bool write_m;
-    
+
     /// Stores the stationary distribution (sigma matrix)
     matrix_type sigma_m;
 
@@ -243,19 +243,19 @@ public:
 
     /// All variables x, px, y, py, z, delta
     Series x_m, px_m, y_m, py_m, z_m, delta_m;
-    
+
     double rinit_m;
     double prinit_m;
 
     /*! Initializes a first guess of the sigma matrix with the assumption of
      * a spherical symmetric beam (ex = ey = ez). For each angle split the
      * same initial guess is taken.
-     * 
+     *
      * @param nuz is the vertical tune
      * @param ravg is the average radius of the closed orbit
      */
     void initialize(value_type, value_type);
-    
+
     /// Computes the new initial sigma matrix
     /*!
      * @param M is the 6x6 one turn transfer matrix
@@ -280,8 +280,8 @@ public:
      * @param newS is the new sigma matrix
      */
     value_type L2ErrorNorm(const matrix_type&, const matrix_type&);
-    
-    
+
+
     /// Returns the Lp-error norm between the old and new sigma-matrix
     /*!
      * @param oldS is the old sigma matrix
@@ -294,7 +294,7 @@ public:
      * @param val is the floating point value which is transformed to a string
      */
     std::string float2string(value_type val);
-    
+
     /// Called within SigmaGenerator::match().
     /*!
      * @param tunes
@@ -469,7 +469,7 @@ template<typename Value_type, typename Size_type>
             // properties of one turn
             tunes = cof.getTunes();
             ravg = cof.getAverageRadius();                   // average radius
-            
+
             value_type angle = cycl->getPHIinit();
             container_type h_turn = cof.getInverseBendingRadius(angle);
             container_type r_turn = cof.getOrbit(angle);
@@ -477,7 +477,7 @@ template<typename Value_type, typename Size_type>
             container_type fidx_turn = cof.getFieldIndex(angle);
 
             container_type peo = cof.getMomentum(angle);
-            
+
             // write properties to file
             if (write_m)
                 writeOrbitOutput_m(tunes, ravg, cof.getFrequencyError(),
@@ -500,15 +500,15 @@ template<typename Value_type, typename Size_type>
             std::copy_n(h_turn.begin(), nSteps_m, h.begin());
             std::copy_n(fidx_turn.begin(), nSteps_m, fidx.begin());
             std::copy_n(ds_turn.begin(), nSteps_m, ds.begin());
-            
+
             rinit_m = r[0];
             prinit_m = peo[0];
-            
+
         } else {
             *gmsg << "Not yet supported." << endl;
             return false;
         }
-        
+
         // initialize sigma matrices (for each angle one) (first guess)
         initialize(tunes.second,ravg);
 
@@ -647,13 +647,13 @@ template<typename Value_type, typename Size_type>
     } catch(const std::exception& e) {
         std::cerr << e.what() << std::endl;
     }
-    
+
     if ( converged_m && write_m ) {
         // write tunes
         std::ofstream writeSigmaMatched("data/MatchedDistributions.dat", std::ios::app);
-        
+
         std::array<double,3> emit = this->getEmittances();
-        
+
         writeSigmaMatched << "* Converged (Ex, Ey, Ez) = (" << emit[0]
                           << ", " << emit[1] << ", " << emit[2]
                           << ") pi mm mrad for E= " << E_m << " (MeV)"
@@ -668,7 +668,7 @@ template<typename Value_type, typename Size_type>
             }
             writeSigmaMatched << " \\\\" << std::endl;
         }
-        
+
         writeSigmaMatched << std::endl;
         writeSigmaMatched.close();
     }
@@ -686,97 +686,97 @@ void SigmaGenerator<Value_type, Size_type>::eigsolve_m(const matrix_type& Mturn,
     typedef gsl_matrix_complex*           gsl_cmatrix_t;
     typedef gsl_eigen_nonsymmv_workspace* gsl_wspace_t;
     typedef boost::numeric::ublas::vector<complex_t> complex_vector_type;
-    
+
     gsl_cvector_t evals = gsl_vector_complex_alloc(6);
     gsl_cmatrix_t evecs = gsl_matrix_complex_alloc(6, 6);
     gsl_wspace_t wspace = gsl_eigen_nonsymmv_alloc(6);
     gsl_matrix_t      M = gsl_matrix_alloc(6, 6);
-    
+
     // go to GSL
     for (size_type i = 0; i < 6; ++i){
         for (size_type j = 0; j < 6; ++j) {
             gsl_matrix_set(M, i, j, Mturn(i,j));
         }
     }
-    
+
     /*int status = */gsl_eigen_nonsymmv(M, evals, evecs, wspace);
-    
+
 //     if ( !status )
 //         throw OpalException("SigmaGenerator::eigsolve_m()",
 //                             "Couldn't perform eigendecomposition!");
-    
+
     /*status = *///gsl_eigen_nonsymmv_sort(evals, evecs, GSL_EIGEN_SORT_ABS_ASC);
-    
+
 //     if ( !status )
 //         throw OpalException("SigmaGenerator::eigsolve_m()",
 //                             "Couldn't sort eigenvalues and eigenvectors!");
-    
+
     // go to UBLAS
     for( size_type i = 0; i < 6; i++){
         gsl_vector_complex_view evec_i = gsl_matrix_complex_column(evecs, i);
-        
+
         for(size_type j = 0;j < 6; j++){
             gsl_complex zgsl = gsl_vector_complex_get(&evec_i.vector, j);
             complex_t z(GSL_REAL(zgsl), GSL_IMAG(zgsl));
             R(i,j) = z;
         }
     }
-    
+
     // Sorting the Eigenvectors
     // This is an arbitrary threshold that has worked for me. (We should fix this)
     value_type threshold = 10e-12;
     bool isZdirection = false;
     std::vector<complex_vector_type> zVectors{};
     std::vector<complex_vector_type> xyVectors{};
-    
+
     for(size_type i = 0; i < 6; i++){
         complex_t z = R(i,0);
-	if(std::abs(z) < threshold) z = 0.;
-	if(z == 0.) isZdirection = true;
-	complex_vector_type v(6);
-	if(isZdirection){
-	    for(size_type j = 0;j < 6; j++){
-	        complex_t z = R(i,j);
-		v(j) = z;
-	    }
-	    zVectors.push_back(v);
-	}
-	else{
-	    for(size_type j = 0; j < 6; j++){
-	        complex_t z = R(i,j);
-		v(j) = z;
-	    }
-	    xyVectors.push_back(v);
-	}
-	isZdirection = false;
+        if(std::abs(z) < threshold) z = 0.;
+        if(z == 0.) isZdirection = true;
+        complex_vector_type v(6);
+        if(isZdirection){
+            for(size_type j = 0;j < 6; j++){
+                complex_t z = R(i,j);
+                v(j) = z;
+            }
+            zVectors.push_back(v);
+        }
+        else{
+            for(size_type j = 0; j < 6; j++){
+                complex_t z = R(i,j);
+                v(j) = z;
+            }
+            xyVectors.push_back(v);
+        }
+        isZdirection = false;
     }
-    
+
     //if z-direction not found, then the system does not behave as expected
     if(zVectors.size() != 2)
         throw OpalException("SigmaGenerator::eigsolve_m()",
                             "Couldn't find the vertical Eigenvectors.");
-    
+
     // Norms the Eigenvectors
      for(size_type i = 0; i < 4; i++){
         value_type norm{0};
         for(size_type j = 0; j < 6; j++) norm += std::norm(xyVectors[i](j));
-	for(size_type j = 0; j < 6; j++) xyVectors[i](j) /= std::sqrt(norm);
+        for(size_type j = 0; j < 6; j++) xyVectors[i](j) /= std::sqrt(norm);
     }
     for(size_type i = 0; i < 2; i++){
         value_type norm{0};
         for(size_type j = 0; j < 6; j++) norm += std::norm(zVectors[i](j));
-	for(size_type j = 0; j < 6; j++) zVectors[i](j) /= std::sqrt(norm);
+        for(size_type j = 0; j < 6; j++) zVectors[i](j) /= std::sqrt(norm);
     }
-    
+
     for(value_type i = 0; i < 6; i++){
         R(i,0) = xyVectors[0](i);
         R(i,1) = xyVectors[1](i);
         R(i,2) = zVectors[0](i);
         R(i,3) = zVectors[1](i);
         R(i,4) = xyVectors[2](i);
-        R(i,5) = xyVectors[3](i); 
+        R(i,5) = xyVectors[3](i);
     }
-    
+
     gsl_vector_complex_free(evals);
     gsl_matrix_complex_free(evecs);
     gsl_eigen_nonsymmv_free(wspace);
@@ -789,25 +789,25 @@ bool SigmaGenerator<Value_type, Size_type>::invertMatrix_m(const sparse_matrix_t
                                                            sparse_matrix_type& invR)
 {
     typedef boost::numeric::ublas::permutation_matrix<size_type> pmatrix_t;
-    
+
     //creates a working copy of R
     cmatrix_type A(R);
-    
+
     //permutation matrix for the LU-factorization
     pmatrix_t pm(A.size1());
-    
+
     //LU-factorization
     int res = lu_factorize(A,pm);
-    
+
     if( res != 0)
         return false;
-    
+
     // create identity matrix of invR
     invR.assign(boost::numeric::ublas::identity_matrix<complex_t>(A.size1()));
-    
+
     // backsubstitute to get the inverse
     boost::numeric::ublas::lu_substitute(A, pm, invR);
-    
+
     return true;
 }
 
@@ -816,9 +816,9 @@ template<typename Value_type, typename Size_type>
 void SigmaGenerator<Value_type, Size_type>::decouple(const matrix_type& Mturn,
                                                      sparse_matrix_type& R,
                                                      sparse_matrix_type& invR)
-{    
+{
     this->eigsolve_m(Mturn, R);
-    
+
     if ( !this->invertMatrix_m(R, invR) )
         throw OpalException("SigmaGenerator::decouple()",
                             "Couldn't compute inverse matrix!");
@@ -996,27 +996,27 @@ void SigmaGenerator<Value_type, Size_type>::initialize(value_type nuz,
     // Remark: We multiply with 10^{6} (= mega) to convert emittances back.
     // 1 m^{2} = 10^{6} mm^{2}
     matrix_type sigma = boost::numeric::ublas::zero_matrix<value_type>(6);
-    
+
     // formula (30), [sigma(0,0)] = m^2 rad * 10^{6} = mm^{2} rad = mm mrad
     sigma(0,0) = invAB * (B * ex / Omega + A * ez / omega) * mega;
-    
+
     // [sigma(0,5)] = [sigma(5,0)] = m rad * 10^{6} = mm mrad	// 1000: m --> mm and 1000 to promille
     sigma(0,5) = sigma(5,0) = invAB * (ex / Omega + ez / omega) * mega;
-    
+
     // [sigma(1,1)] = rad * 10^{6} = mrad (and promille)
     sigma(1,1) = invAB * (B * ex * Omega + A * ez * omega) * mega;
-    
+
     // [sigma(1,4)] = [sigma(4,1)] = m rad * 10^{6} = mm mrad
     sigma(1,4) = sigma(4,1) = invAB * (ex * Omega+ez * omega) / (K * gamma2_m) * mega;
-    
+
     // formula (31), [sigma(2,2)] = m rad * 10^{6} = mm mrad
     sigma(2,2) = ey / (std::sqrt(h * h * nuz * nuz - K)) * mega;
-    
+
     sigma(3,3) = (ey * mega) * (ey * mega) / sigma(2,2);
-    
+
     // [sigma(4,4)] = m^{2} rad * 10^{6} = mm^{2} rad = mm mrad
     sigma(4,4) = invAB * (A * ex * Omega + B * ez * omega) / (K * gamma2_m) * mega;
-    
+
     // formula (30), [sigma(5,5)] = rad * 10^{6} = mrad (and promille)
     sigma(5,5) = invAB * (ex / (B * Omega) + ez / (A * omega)) * mega;
 
@@ -1054,16 +1054,16 @@ SigmaGenerator<Value_type, Size_type>::updateInitialSigma(const matrix_type& M,
      * with diagonal matrix D (stores eigenvalues of sigma*S (emittances apart from +- i),
      * skew-symmetric matrix (formula (13)), and tranformation matrices E, E^{-1}
      */
-    
+
     cmatrix_type S = boost::numeric::ublas::zero_matrix<complex_t>(6,6);
     S(0,1) = S(2,3) = S(4,5) = 1;
     S(1,0) = S(3,2) = S(5,4) = -1;
-    
+
     // Build new D-Matrix
     // Section 2.4 Eq. 18 in M. Frey Semester thesis
-    // D = diag(i*emx,-i*emx,i*emy,-i*emy,i*emz, -i*emz) 
-    
-    
+    // D = diag(i*emx,-i*emx,i*emy,-i*emy,i*emz, -i*emz)
+
+
     cmatrix_type D = boost::numeric::ublas::zero_matrix<complex_t>(6,6);
     value_type invbg = 1.0 / (beta_m * gamma_m);
     complex_t im(0,1);
@@ -1071,18 +1071,18 @@ SigmaGenerator<Value_type, Size_type>::updateInitialSigma(const matrix_type& M,
         D(2*i, 2*i) = emittance_m[i] * invbg * im;
         D(2*i+1, 2*i+1) = -emittance_m[i] * invbg * im;
     }
-    
+
     // Computing of new Sigma
     // sigma = -R*D*R^{-1}*S
     cmatrix_type csigma(6, 6);
     csigma = boost::numeric::ublas::prod(invR, S);
     csigma = boost::numeric::ublas::prod(D, csigma);
     csigma = boost::numeric::ublas::prod(-R, csigma);
-    
+
     matrix_type sigma(6,6);
     for (size_type i = 0; i < 6; ++i){
         for (size_type j = 0; j < 6; ++j){
-            sigma(i,j) = csigma(i,j).real(); 
+            sigma(i,j) = csigma(i,j).real();
         }
     }
 
@@ -1160,7 +1160,7 @@ typename SigmaGenerator<Value_type, Size_type>::value_type
 {
     // compute difference
     matrix_type diff = newS - oldS;
-    
+
     std::for_each(diff.data().begin(), diff.data().end(),
                   [](value_type& val) {
                       return std::abs(val);
@@ -1197,20 +1197,20 @@ void SigmaGenerator<Value_type, Size_type>::writeOrbitOutput_m(
         writeTunes << "energy [MeV]" << std::setw(15)
                    << "nur" << std::setw(25)
                    << "nuz" << std::endl;
-    
+
     writeTunes << E_m << std::setw(30) << std::setprecision(10)
                << tunes.first << std::setw(25)
                << tunes.second << std::endl;
-    
+
     // write average radius
     std::ofstream writeAvgRadius("data/AverageValues.dat", std::ios::app);
-    
+
     if (writeAvgRadius.tellp() == 0) // if nothing yet written --> write description
         writeAvgRadius << "energy [MeV]" << std::setw(15)
                        << "avg. radius [m]" << std::setw(15)
                        << "r [m]" << std::setw(15)
                        << "pr [m]" << std::endl;
-    
+
     writeAvgRadius << E_m << std::setw(25) << std::setprecision(10)
                    << ravg << std::setw(25) << std::setprecision(10)
                    << r_turn[0] << std::setw(25) << std::setprecision(10)
@@ -1222,7 +1222,7 @@ void SigmaGenerator<Value_type, Size_type>::writeOrbitOutput_m(
     if(writePhase.tellp() == 0) // if nothing yet written --> write description
         writePhase << "energy [MeV]" << std::setw(15)
                    << "freq. error" << std::endl;
-    
+
     writePhase << E_m << std::setw(30) << std::setprecision(10)
                << freqError << std::endl;
 
@@ -1235,7 +1235,7 @@ void SigmaGenerator<Value_type, Size_type>::writeOrbitOutput_m(
                     << std::setw(25) << "inverse bending radius"
                     << std::setw(25) << "field index"
                     << std::setw(25) << "path length" << std::endl;
-        
+
     for (size_type i = 0; i < r_turn.size(); ++i) {
         writeProperties << std::setprecision(10) << std::left
                         << std::setw(25) << r_turn[i]
@@ -1244,7 +1244,7 @@ void SigmaGenerator<Value_type, Size_type>::writeOrbitOutput_m(
                         << std::setw(25) << fidx_turn[i]
                         << std::setw(25) << ds_turn[i] << std::endl;
     }
-        
+
     // close all files within this if-statement
     writeTunes.close();
     writeAvgRadius.close();

--- a/src/Distribution/rdm.h
+++ b/src/Distribution/rdm.h
@@ -37,10 +37,10 @@ class RDM
         typedef boost::numeric::ublas::matrix<value_type> matrix_type;
         /// Dense vector type definition
         typedef boost::numeric::ublas::vector<value_type> vector_type;
-        
+
         /// Default constructor (sets only NumOfRDMs and DimOfRDMs)
         RDM();
-        
+
         /// Returns the i-th Real Dirac matrix
         /*!
          * @param i specifying the matrix (has to be in the range from 0 to 15)
@@ -105,24 +105,24 @@ RDM<Value_type, Size_type>::RDM() : NumOfRDMs(16), DimOfRDMs(4) {};
 
 template<typename Value_type, typename Size_type>
 typename RDM<Value_type, Size_type>::sparse_matrix_type RDM<Value_type, Size_type>::getRDM(short i) {
-    sparse_matrix_type rdm(4,4,4);	// #nrows, #ncols, #non-zeros
+    sparse_matrix_type rdm(4,4,4);  // #nrows, #ncols, #non-zeros
     switch(i) {
-        case 0: rdm(0,1) = rdm(2,3) = 1; rdm(1,0) = rdm(3,2) = -1; 	break;
-        case 1: rdm(0,1) = rdm(1,0) = -1; rdm(2,3) = rdm(3,2) = 1; 	break;
-        case 2: rdm(0,3) = rdm(1,2) = rdm(2,1) = rdm(3,0) = 1; 	break;
-        case 3: rdm(0,0) = rdm(2,2) = -1; rdm(1,1) = rdm(3,3) = 1; 	break;
-        case 4: rdm(0,0) = rdm(3,3) = -1; rdm(1,1) = rdm(2,2) = 1;	break;
-        case 5: rdm(0,2) = rdm(2,0) = 1; rdm(1,3) = rdm(3,1) = -1; 	break;
-        case 6: rdm(0,1) = rdm(1,0) = rdm(2,3) = rdm(3,2) = 1;	break;
-        case 7: rdm(0,3) = rdm(2,1) = 1; rdm(1,2) = rdm(3,0) = -1;	break;
-        case 8: rdm(0,1) = rdm(3,2) = 1; rdm(1,0) = rdm(2,3) = -1;	break;
-        case 9: rdm(0,2) = rdm(1,3) = -1; rdm(2,0) = rdm(3,1) = 1;	break;
-        case 10: rdm(0,2) = rdm(3,1) = 1; rdm(1,3) = rdm(2,0) = -1;	break;
-        case 11: rdm(0,2) = rdm(1,3) = rdm(2,0) = rdm(3,1) = -1;	break;
-        case 12: rdm(0,0) = rdm(1,1) = -1; rdm(2,2) = rdm(3,3) = 1;	break;
-        case 13: rdm(0,3) = rdm(3,0) = -1; rdm(1,2) = rdm(2,1) = 1;	break;
-        case 14: rdm(0,3) = rdm(1,2) = -1; rdm(2,1) = rdm(3,0) = 1;	break;
-        case 15: rdm(0,0) = rdm(1,1) = rdm(2,2) = rdm(3,3) = 1;	break;
+        case 0: rdm(0,1) = rdm(2,3) = 1; rdm(1,0) = rdm(3,2) = -1;  break;
+        case 1: rdm(0,1) = rdm(1,0) = -1; rdm(2,3) = rdm(3,2) = 1;  break;
+        case 2: rdm(0,3) = rdm(1,2) = rdm(2,1) = rdm(3,0) = 1;  break;
+        case 3: rdm(0,0) = rdm(2,2) = -1; rdm(1,1) = rdm(3,3) = 1;  break;
+        case 4: rdm(0,0) = rdm(3,3) = -1; rdm(1,1) = rdm(2,2) = 1;  break;
+        case 5: rdm(0,2) = rdm(2,0) = 1; rdm(1,3) = rdm(3,1) = -1;  break;
+        case 6: rdm(0,1) = rdm(1,0) = rdm(2,3) = rdm(3,2) = 1;  break;
+        case 7: rdm(0,3) = rdm(2,1) = 1; rdm(1,2) = rdm(3,0) = -1;  break;
+        case 8: rdm(0,1) = rdm(3,2) = 1; rdm(1,0) = rdm(2,3) = -1;  break;
+        case 9: rdm(0,2) = rdm(1,3) = -1; rdm(2,0) = rdm(3,1) = 1;  break;
+        case 10: rdm(0,2) = rdm(3,1) = 1; rdm(1,3) = rdm(2,0) = -1; break;
+        case 11: rdm(0,2) = rdm(1,3) = rdm(2,0) = rdm(3,1) = -1;    break;
+        case 12: rdm(0,0) = rdm(1,1) = -1; rdm(2,2) = rdm(3,3) = 1; break;
+        case 13: rdm(0,3) = rdm(3,0) = -1; rdm(1,2) = rdm(2,1) = 1; break;
+        case 14: rdm(0,3) = rdm(1,2) = -1; rdm(2,1) = rdm(3,0) = 1; break;
+        case 15: rdm(0,0) = rdm(1,1) = rdm(2,2) = rdm(3,3) = 1; break;
         default: throw std::out_of_range("Error in RDM::generate: 0 <= i <= 15"); break;
     }
     return rdm;
@@ -196,8 +196,8 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     P(0) = mult(1); P(1) = mult(2); P(2) = mult(3);
     E(0) = mult(4); E(1) = mult(5); E(2) = mult(6);
     B(0) = -mult(7); B(1) = -mult(8); B(2) = -mult(9);
-    mr = boost::numeric::ublas::inner_prod(E,B);		// formula (31), paper: Geometrical method of decoupling
-    mg = boost::numeric::ublas::inner_prod(B,P);		// formula (31), paper: Geometrical method of decoupling
+    mr = boost::numeric::ublas::inner_prod(E,B);        // formula (31), paper: Geometrical method of decoupling
+    mg = boost::numeric::ublas::inner_prod(B,P);        // formula (31), paper: Geometrical method of decoupling
 
     transform(Ms,short(0),0.5 * std::atan2(mg,mr),R,invR);
 
@@ -206,7 +206,7 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     P(0) = mult(1); P(1) = mult(2); P(2) = mult(3);
     E(0) = mult(4); E(1) = mult(5); E(2) = mult(6);
     B(0) = -mult(7); B(1) = -mult(8); B(2) = -mult(9);
-    b = eps*B+matt_boost::cross_prod(E,P);		// formula (32), paper: Geometrical method of decoupling
+    b = eps*B+matt_boost::cross_prod(E,P);        // formula (32), paper: Geometrical method of decoupling
 
     transform(Ms,short(7),0.5 * std::atan2(b(2),b(1)),R,invR);
 
@@ -215,7 +215,7 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     P(0) = mult(1); P(1) = mult(2); P(2) = mult(3);
     E(0) = mult(4); E(1) = mult(5); E(2) = mult(6);
     B(0) = -mult(7); B(1) = -mult(8); B(2) = -mult(9);
-    b = eps*B+matt_boost::cross_prod(E,P);  
+    b = eps*B+matt_boost::cross_prod(E,P);
 
     transform(Ms,short(9),-0.5 * std::atan2(b(0),b(1)),R,invR);
 
@@ -226,7 +226,7 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     B(0) = -mult(7); B(1) = -mult(8); B(2) = -mult(9);
     mr = boost::numeric::ublas::inner_prod(E,B);
     b = eps*B+matt_boost::cross_prod(E,P);
-    
+
     // Transformation distinction made according to function "rdm_Decouple_F" in rdm.c of Dr. Christian Baumgarten
 
     if (std::fabs(mr) < std::fabs(b(1))) {
@@ -234,7 +234,7 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     } else {
         transform(Ms,short(2),0.5 * std::atanh(b(1) / mr),R,invR);
     }
-    
+
     eps = -mult(0);
     P(0) = mult(1); P(1) = mult(2); P(2) = mult(3);
     E(0) = mult(4); E(1) = mult(5); E(2) = mult(6);
@@ -244,16 +244,16 @@ void RDM<Value_type, Size_type>::diagonalize(matrix_type& Ms, sparse_matrix_type
     mr = boost::numeric::ublas::inner_prod(E,B);
     mg = boost::numeric::ublas::inner_prod(B,P);
     mb = boost::numeric::ublas::inner_prod(E,P);
-    
+
     value_type P2 = boost::numeric::ublas::inner_prod(P,P);
     value_type E2 = boost::numeric::ublas::inner_prod(E,E);
-    
+
     // 5. Transform with \gamma_{0}
     transform(Ms,short(0),0.25 * std::atan2(mb,0.5 * (E2 - P2)),R,invR);
 
     // 6. Transformation with \gamma_{8}
     P(0) = mult(1); P(2) = mult(3);
-    
+
     transform(Ms,short(8),-0.5 * std::atan2(P(2),P(0)),R,invR);
 }
 
@@ -282,7 +282,7 @@ typename RDM<Value_type, Size_type>::matrix_type RDM<Value_type, Size_type>::cos
 
 template<typename Value_type, typename Size_type>
 void RDM<Value_type, Size_type>::transform(matrix_type& M, short i, value_type phi, sparse_matrix_type& Rtot, sparse_matrix_type& invRtot) {
-    
+
     if (phi) {  // if phi == 0 --> nothing happens, since R and invR would be identity_matrix matrix
         sparse_matrix_type R(4,4), invR(4,4);
         sparse_matrix_type I = boost::numeric::ublas::identity_matrix<value_type>(4);

--- a/src/Elements/OpalBeamline.cpp
+++ b/src/Elements/OpalBeamline.cpp
@@ -130,7 +130,7 @@ void OpalBeamline::switchElements(const double &min, const double &max, const do
             }
         }
 
-	fprev = flit;
+        fprev = flit;
     }
 }
 

--- a/src/Elements/OpalBend.h
+++ b/src/Elements/OpalBend.h
@@ -48,8 +48,8 @@ public:
         ROTATION,         // Magnet rotation about z axis.
         DESIGNENERGY,     // the design energy of the particles
         GREATERTHANPI,    // Boolean flag set to true if bend angle is greater
-		NSLICES,	  // The number of slices / steps per element for map tracking
-        // than 180 degrees.
+                          // than 180 degrees.
+        NSLICES,          // The number of slices / steps per element for map tracking
         SIZE              // Total number of attributes.
     };
 

--- a/src/Elements/OpalCavity.cpp
+++ b/src/Elements/OpalCavity.cpp
@@ -179,7 +179,7 @@ void OpalCavity::update() {
     if(itsAttr[GEOMETRY] && obgeo_m == NULL) {
         obgeo_m = (BoundaryGeometry::find(Attributes::getString(itsAttr[GEOMETRY])))->clone(getOpalName() + std::string("_geometry"));
         if(obgeo_m) {
-	    rfc->setBoundaryGeometry(obgeo_m);
+            rfc->setBoundaryGeometry(obgeo_m);
         }
     }
 

--- a/src/Elements/OpalCavity.h
+++ b/src/Elements/OpalCavity.h
@@ -54,9 +54,9 @@ public:
         GAPWIDTH,       // constant gap width of cavity
         PHI0,           // initial phase of cavity
         DESIGNENERGY,   // The mean kinetic energy at exit
-	PHASE_MODEL,    // time dependent phase
-	AMPLITUDE_MODEL,// time dependent amplitude
-	FREQUENCY_MODEL,// time dependent frequency
+        PHASE_MODEL,    // time dependent phase
+        AMPLITUDE_MODEL,// time dependent amplitude
+        FREQUENCY_MODEL,// time dependent frequency
         SIZE
     };
 

--- a/src/Elements/OpalCyclotron.cpp
+++ b/src/Elements/OpalCyclotron.cpp
@@ -233,14 +233,14 @@ void OpalCyclotron::update() {
     std::vector<std::string> trimcoil   = Attributes::getStringArray(itsAttr[TRIMCOIL]);
 
     if ( !trimcoil.empty() ) {
-        
+
         std::vector<TrimCoil* > trimcoils;
-        
+
         for (std::vector<std::string>::const_iterator tit = trimcoil.begin();
              tit != trimcoil.end(); ++tit)
         {
             OpalTrimCoil *tc = OpalTrimCoil::find(*tit);
-            
+
             if ( tc ) {
                 tc->initOpalTrimCoil();
                 trimcoils.push_back(tc->trimcoil_m.get());
@@ -260,7 +260,7 @@ void OpalCyclotron::update() {
     if(itsAttr[GEOMETRY] && obgeo_m == nullptr) {
       obgeo_m = BoundaryGeometry::find(Attributes::getString(itsAttr[GEOMETRY]));
       if(obgeo_m) {
-	cycl->setBoundaryGeometry(obgeo_m);
+          cycl->setBoundaryGeometry(obgeo_m);
       }
     }
 

--- a/src/Elements/OpalDrift.cpp
+++ b/src/Elements/OpalDrift.cpp
@@ -70,7 +70,7 @@ OpalDrift::~OpalDrift() {
     if(parmatint_m)
         delete parmatint_m;
     if(obgeo_m)
-	delete obgeo_m;
+        delete obgeo_m;
 }
 
 
@@ -104,7 +104,7 @@ void OpalDrift::update() {
     if(itsAttr[GEOMETRY] && obgeo_m == NULL) {
         obgeo_m = (BoundaryGeometry::find(Attributes::getString(itsAttr[GEOMETRY])))->clone(getOpalName() + std::string("_geometry"));
         if(obgeo_m) {
-	    drf->setBoundaryGeometry(obgeo_m);
+            drf->setBoundaryGeometry(obgeo_m);
         }
     }
 

--- a/src/Elements/OpalDrift.h
+++ b/src/Elements/OpalDrift.h
@@ -34,10 +34,9 @@ class OpalDrift: public OpalElement {
 public:
 
     enum {
-         GEOMETRY = COMMON,       // geometry of boundary, one more enum member besides the common ones in OpalElement.
-		 NSLICES,	  // The number of slices / steps per element for map tracking
-	 SIZE
-
+         GEOMETRY = COMMON,  // geometry of boundary, one more enum member besides the common ones in OpalElement.
+         NSLICES,            // The number of slices / steps per element for map tracking
+         SIZE
     };
     /// Exemplar constructor.
     OpalDrift();

--- a/src/Elements/OpalMultipoleT.h
+++ b/src/Elements/OpalMultipoleT.h
@@ -34,7 +34,7 @@
 
 /** OpalMultipoleT provides user interface information for the MultipoleT object
  *
- *  Defines input parameters 
+ *  Defines input parameters
  */
 class OpalMultipoleT: public OpalElement {
 
@@ -43,20 +43,20 @@ public:
     // The attributes of class OpalMultipoleT
     enum {
         TP = COMMON,     // Transverse field components
-	RFRINGE,         // Length of right fringe field
-	LFRINGE,         // Length of left fringe field
-	HAPERT,          // Aperture horizontal dimension
-	VAPERT,          // Aperture vertical dimension
-	MAXFORDER,       // Maximum order in the field expansion
+        RFRINGE,         // Length of right fringe field
+        LFRINGE,         // Length of left fringe field
+        HAPERT,          // Aperture horizontal dimension
+        VAPERT,          // Aperture vertical dimension
+        MAXFORDER,       // Maximum order in the field expansion
         MAXXORDER,       // Maximum order in x in polynomial expansions
-	ANGLE,           // Bending angle of a sector magnet
-	ROTATION,        // Rotation angle about central axis for skew elements
-	EANGLE,          // Entrance angle
-	VARRADIUS,       // Variable radius flag
+        ANGLE,           // Bending angle of a sector magnet
+        ROTATION,        // Rotation angle about central axis for skew elements
+        EANGLE,          // Entrance angle
+        VARRADIUS,       // Variable radius flag
         BBLENGTH,        // Distance between centre of magnet and entrance
-	SIZE             // size of the enum
+        SIZE             // size of the enum
     };
-    
+
     /** Default constructor initialises UI parameters. */
     OpalMultipoleT();
 
@@ -87,8 +87,3 @@ public:
 };
 
 #endif // OPAL_OpalMultipoleT_HH
-   
- 
-  
-
-

--- a/src/Elements/OpalMultipoleTCurvedConstRadius.cpp
+++ b/src/Elements/OpalMultipoleTCurvedConstRadius.cpp
@@ -63,13 +63,13 @@ OpalMultipoleTCurvedConstRadius::OpalMultipoleTCurvedConstRadius():
     itsAttr[EANGLE] = Attributes::makeReal
                   ("EANGLE", "The entrance angle (rad)");
     itsAttr[MAXFORDER] = Attributes::makeReal
-                  ("MAXFORDER", 
+                  ("MAXFORDER",
                    "Number of terms used in each field component");
     itsAttr[MAXXORDER] = Attributes::makeReal
-                  ("MAXXORDER", 
+                  ("MAXXORDER",
                    "Number of terms used in polynomial expansions");
     itsAttr[ROTATION] = Attributes::makeReal
-                  ("ROTATION", 
+                  ("ROTATION",
                    "Rotation angle about its axis for skew elements (rad)");
     itsAttr[BBLENGTH] = Attributes::makeReal
                   ("BBLENGTH",
@@ -82,8 +82,8 @@ OpalMultipoleTCurvedConstRadius::OpalMultipoleTCurvedConstRadius():
 }
 
 
-OpalMultipoleTCurvedConstRadius::OpalMultipoleTCurvedConstRadius(const std::string &name, 
-			       OpalMultipoleTCurvedConstRadius *parent):
+OpalMultipoleTCurvedConstRadius::OpalMultipoleTCurvedConstRadius(const std::string &name,
+                                                                 OpalMultipoleTCurvedConstRadius *parent):
     OpalElement(name, parent) {
     setElement((new MultipoleTCurvedConstRadius(name))->makeWrappers());
 }
@@ -105,16 +105,16 @@ void OpalMultipoleTCurvedConstRadius::print(std::ostream &os) const {
 
 void OpalMultipoleTCurvedConstRadius::
 fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
-    OpalElement::fillRegisteredAttributes(base, flag);   
-    const MultipoleTCurvedConstRadius *multT = 
+    OpalElement::fillRegisteredAttributes(base, flag);
+    const MultipoleTCurvedConstRadius *multT =
         dynamic_cast<const MultipoleTCurvedConstRadius*>(base.removeAlignWrapper());
-    
+
     for(unsigned int order = 1; order <= multT->getTransMaxOrder(); order++) {
         std::ostringstream ss;
-	ss << order;
-	std::string orderString = ss.str();
+        ss << order;
+        std::string orderString = ss.str();
         std::string attrName = "TP" + orderString;
-	registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
+        registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
     }
 
     registerRealAttribute("LFRINGE")->setReal(multT->getFringeLength().at(0));
@@ -127,7 +127,7 @@ fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
     registerRealAttribute("ANGLE")->setReal(multT->getBendAngle());
     registerRealAttribute("EANGLE")->setReal(multT->getEntranceAngle());
     registerRealAttribute("BBLENGTH")->setReal(multT->getBoundingBoxLength());
-    
+
 }
 
 
@@ -143,14 +143,14 @@ void OpalMultipoleTCurvedConstRadius::update() {
     multT->setElementLength(length);
     multT->setLength(length);
     multT->setBendAngle(angle);
-    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]), 
-		       Attributes::getReal(itsAttr[HAPERT]));
-  
+    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]),
+                       Attributes::getReal(itsAttr[HAPERT]));
+
     multT->setFringeField(Attributes::getReal(itsAttr[LENGTH])/2,
                           Attributes::getReal(itsAttr[LFRINGE]),
-                          Attributes::getReal(itsAttr[RFRINGE])); 
+                          Attributes::getReal(itsAttr[RFRINGE]));
     multT->setBoundingBoxLength(Attributes::getReal(itsAttr[BBLENGTH]));
-    const std::vector<double> transProfile = 
+    const std::vector<double> transProfile =
                               Attributes::getRealArray(itsAttr[TP]);
     std::size_t transSize = transProfile.size();
     if (transSize == 0) {
@@ -165,13 +165,13 @@ void OpalMultipoleTCurvedConstRadius::update() {
     multT->setEntranceAngle(Attributes::getReal(itsAttr[EANGLE]));
 
     PlanarArcGeometry &geometry = multT->getGeometry();
-    
+
     if(length) {
         geometry = PlanarArcGeometry(2 * boundingBoxLength, angle / length);
     } else {
         geometry = PlanarArcGeometry(angle);
     }
-    
+
     for(std::size_t comp = 0; comp < transSize; comp++) {
         multT->setTransProfile(comp, transProfile[comp]);
     }

--- a/src/Elements/OpalMultipoleTCurvedConstRadius.h
+++ b/src/Elements/OpalMultipoleTCurvedConstRadius.h
@@ -35,7 +35,7 @@
 
 /** OpalMultipoleTCurvedConstRadius provides user interface information for the MultipoleTCurvedConstRadius object
  *
- *  Defines input parameters 
+ *  Defines input parameters
  */
 class OpalMultipoleTCurvedConstRadius: public OpalElement {
 
@@ -44,19 +44,19 @@ public:
     // The attributes of class OpalMultipoleTCurvedConstRadius
     enum {
         TP = COMMON,     // Transverse field components
-	RFRINGE,         // Length of right fringe field
-	LFRINGE,         // Length of left fringe field
-	HAPERT,          // Aperture horizontal dimension
-	VAPERT,          // Aperture vertical dimension
-	MAXFORDER,       // Maximum order in the field expansion
+        RFRINGE,         // Length of right fringe field
+        LFRINGE,         // Length of left fringe field
+        HAPERT,          // Aperture horizontal dimension
+        VAPERT,          // Aperture vertical dimension
+        MAXFORDER,       // Maximum order in the field expansion
         MAXXORDER,       // Maximum order in x in polynomial expansions
-	ANGLE,           // Bending angle of a sector magnet
-	ROTATION,        // Rotation angle about central axis for skew elements
-	EANGLE,          // Entrance angle
+        ANGLE,           // Bending angle of a sector magnet
+        ROTATION,        // Rotation angle about central axis for skew elements
+        EANGLE,          // Entrance angle
         BBLENGTH,        // Distance between centre of magnet and entrance
-	SIZE             // size of the enum
+        SIZE             // size of the enum
     };
-    
+
     /** Default constructor initialises UI parameters. */
     OpalMultipoleTCurvedConstRadius();
 
@@ -87,8 +87,3 @@ public:
 };
 
 #endif
-   
- 
-  
-
-

--- a/src/Elements/OpalMultipoleTCurvedVarRadius.cpp
+++ b/src/Elements/OpalMultipoleTCurvedVarRadius.cpp
@@ -63,13 +63,13 @@ OpalMultipoleTCurvedVarRadius::OpalMultipoleTCurvedVarRadius():
     itsAttr[EANGLE] = Attributes::makeReal
                   ("EANGLE", "The entrance angle (rad)");
     itsAttr[MAXFORDER] = Attributes::makeReal
-                  ("MAXFORDER", 
+                  ("MAXFORDER",
                    "Number of terms used in each field component");
     itsAttr[MAXXORDER] = Attributes::makeReal
-                  ("MAXXORDER", 
+                  ("MAXXORDER",
                    "Number of terms used in polynomial expansions");
     itsAttr[ROTATION] = Attributes::makeReal
-                  ("ROTATION", 
+                  ("ROTATION",
                    "Rotation angle about its axis for skew elements (rad)");
     itsAttr[BBLENGTH] = Attributes::makeReal
                   ("BBLENGTH",
@@ -81,8 +81,8 @@ OpalMultipoleTCurvedVarRadius::OpalMultipoleTCurvedVarRadius():
 }
 
 
-OpalMultipoleTCurvedVarRadius::OpalMultipoleTCurvedVarRadius(const std::string &name, 
-			       OpalMultipoleTCurvedVarRadius *parent):
+OpalMultipoleTCurvedVarRadius::OpalMultipoleTCurvedVarRadius(const std::string &name,
+                                                             OpalMultipoleTCurvedVarRadius *parent):
     OpalElement(name, parent) {
     setElement((new MultipoleTCurvedVarRadius(name))->makeWrappers());
 }
@@ -104,16 +104,16 @@ void OpalMultipoleTCurvedVarRadius::print(std::ostream &os) const {
 
 void OpalMultipoleTCurvedVarRadius::
 fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
-    OpalElement::fillRegisteredAttributes(base, flag);   
-    const MultipoleTCurvedVarRadius *multT = 
+    OpalElement::fillRegisteredAttributes(base, flag);
+    const MultipoleTCurvedVarRadius *multT =
         dynamic_cast<const MultipoleTCurvedVarRadius*>(base.removeAlignWrapper());
-    
+
     for(unsigned int order = 1; order <= multT->getTransMaxOrder(); order++) {
         std::ostringstream ss;
-	ss << order;
-	std::string orderString = ss.str();
+        ss << order;
+        std::string orderString = ss.str();
         std::string attrName = "TP" + orderString;
-	registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
+        registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
     }
 
     registerRealAttribute("LFRINGE")->setReal(multT->getFringeLength().at(0));
@@ -125,7 +125,7 @@ fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
     registerRealAttribute("ROTATION")->setReal(multT->getRotation());
     registerRealAttribute("EANGLE")->setReal(multT->getEntranceAngle());
     registerRealAttribute("BBLENGTH")->setReal(multT->getBoundingBoxLength());
-    
+
 }
 
 
@@ -141,14 +141,14 @@ void OpalMultipoleTCurvedVarRadius::update() {
     multT->setElementLength(length);
     multT->setLength(length);
     multT->setBendAngle(angle);
-    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]), 
-		       Attributes::getReal(itsAttr[HAPERT]));
-  
+    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]),
+                       Attributes::getReal(itsAttr[HAPERT]));
+
     multT->setFringeField(Attributes::getReal(itsAttr[LENGTH])/2,
                           Attributes::getReal(itsAttr[LFRINGE]),
-                          Attributes::getReal(itsAttr[RFRINGE])); 
+                          Attributes::getReal(itsAttr[RFRINGE]));
     multT->setBoundingBoxLength(Attributes::getReal(itsAttr[BBLENGTH]));
-    const std::vector<double> transProfile = 
+    const std::vector<double> transProfile =
                               Attributes::getRealArray(itsAttr[TP]);
     std::size_t transSize = transProfile.size();
 
@@ -163,13 +163,13 @@ void OpalMultipoleTCurvedVarRadius::update() {
     multT->setEntranceAngle(Attributes::getReal(itsAttr[EANGLE]));
 
     VarRadiusGeometry &geometry = multT->getGeometry();
-    
+
     geometry = VarRadiusGeometry(2 * boundingBoxLength,
                                  (length / angle),
                                   length / 2,
                                   Attributes::getReal(itsAttr[LFRINGE]),
                                   Attributes::getReal(itsAttr[RFRINGE]));
-    
+
     for(std::size_t comp = 0; comp < transSize; comp++) {
         multT->setTransProfile(comp, transProfile[comp]);
     }

--- a/src/Elements/OpalMultipoleTCurvedVarRadius.h
+++ b/src/Elements/OpalMultipoleTCurvedVarRadius.h
@@ -35,7 +35,7 @@
 
 /** OpalMultipoleTCurvedVarRadius provides user interface information for the MultipoleTCurvedVarRadius object
  *
- *  Defines input parameters 
+ *  Defines input parameters
  */
 class OpalMultipoleTCurvedVarRadius: public OpalElement {
 
@@ -44,19 +44,19 @@ public:
     // The attributes of class OpalMultipoleTCurvedVarRadius
     enum {
         TP = COMMON,     // Transverse field components
-	RFRINGE,         // Length of right fringe field
-	LFRINGE,         // Length of left fringe field
-	HAPERT,          // Aperture horizontal dimension
-	VAPERT,          // Aperture vertical dimension
-	MAXFORDER,       // Maximum order in the field expansion
+        RFRINGE,         // Length of right fringe field
+        LFRINGE,         // Length of left fringe field
+        HAPERT,          // Aperture horizontal dimension
+        VAPERT,          // Aperture vertical dimension
+        MAXFORDER,       // Maximum order in the field expansion
         MAXXORDER,       // Maximum order in x in polynomial expansions
-	ANGLE,           // Bending angle of a sector magnet
-	ROTATION,        // Rotation angle about central axis for skew elements
-	EANGLE,          // Entrance angle
+        ANGLE,           // Bending angle of a sector magnet
+        ROTATION,        // Rotation angle about central axis for skew elements
+        EANGLE,          // Entrance angle
         BBLENGTH,        // Distance between centre of magnet and entrance
-	SIZE             // size of the enum
+        SIZE             // size of the enum
     };
-    
+
     /** Default constructor initialises UI parameters. */
     OpalMultipoleTCurvedVarRadius();
 
@@ -87,8 +87,3 @@ public:
 };
 
 #endif
-   
- 
-  
-
-

--- a/src/Elements/OpalMultipoleTStraight.cpp
+++ b/src/Elements/OpalMultipoleTStraight.cpp
@@ -61,10 +61,10 @@ OpalMultipoleTStraight::OpalMultipoleTStraight():
     itsAttr[EANGLE] = Attributes::makeReal
                   ("EANGLE", "The entrance angle (rad)");
     itsAttr[MAXFORDER] = Attributes::makeReal
-                  ("MAXFORDER", 
+                  ("MAXFORDER",
                    "Number of terms used in each field component");
     itsAttr[ROTATION] = Attributes::makeReal
-                  ("ROTATION", 
+                  ("ROTATION",
                    "Rotation angle about its axis for skew elements (rad)");
     itsAttr[BBLENGTH] = Attributes::makeReal
                   ("BBLENGTH",
@@ -76,8 +76,8 @@ OpalMultipoleTStraight::OpalMultipoleTStraight():
 }
 
 
-OpalMultipoleTStraight::OpalMultipoleTStraight(const std::string &name, 
-			       OpalMultipoleTStraight *parent):
+OpalMultipoleTStraight::OpalMultipoleTStraight(const std::string &name,
+                                               OpalMultipoleTStraight *parent):
     OpalElement(name, parent) {
     setElement((new MultipoleTStraight(name))->makeWrappers());
 }
@@ -99,16 +99,16 @@ void OpalMultipoleTStraight::print(std::ostream &os) const {
 
 void OpalMultipoleTStraight::
 fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
-    OpalElement::fillRegisteredAttributes(base, flag);   
-    const MultipoleTStraight *multT = 
+    OpalElement::fillRegisteredAttributes(base, flag);
+    const MultipoleTStraight *multT =
         dynamic_cast<const MultipoleTStraight*>(base.removeAlignWrapper());
-    
+
     for(unsigned int order = 1; order <= multT->getTransMaxOrder(); order++) {
         std::ostringstream ss;
-	ss << order;
-	std::string orderString = ss.str();
+        ss << order;
+        std::string orderString = ss.str();
         std::string attrName = "TP" + orderString;
-	registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
+        registerRealAttribute(attrName)->setReal(multT->getTransProfile(order));
     }
 
     registerRealAttribute("LFRINGE")->setReal(multT->getFringeLength().at(0));
@@ -119,7 +119,7 @@ fillRegisteredAttributes(const ElementBase &base, ValueFlag flag) {
     registerRealAttribute("ROTATION")->setReal(multT->getRotation());
     registerRealAttribute("EANGLE")->setReal(multT->getEntranceAngle());
     registerRealAttribute("BBLENGTH")->setReal(multT->getBoundingBoxLength());
-    
+
 }
 
 
@@ -133,14 +133,14 @@ void OpalMultipoleTStraight::update() {
     double boundingBoxLength = Attributes::getReal(itsAttr[BBLENGTH]);
     multT->setElementLength(length);
     multT->setLength(length);
-    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]), 
-		       Attributes::getReal(itsAttr[HAPERT]));
-  
+    multT->setAperture(Attributes::getReal(itsAttr[VAPERT]),
+                       Attributes::getReal(itsAttr[HAPERT]));
+
     multT->setFringeField(Attributes::getReal(itsAttr[LENGTH])/2,
                           Attributes::getReal(itsAttr[LFRINGE]),
-                          Attributes::getReal(itsAttr[RFRINGE])); 
+                          Attributes::getReal(itsAttr[RFRINGE]));
     multT->setBoundingBoxLength(Attributes::getReal(itsAttr[BBLENGTH]));
-    const std::vector<double> transProfile = 
+    const std::vector<double> transProfile =
                               Attributes::getRealArray(itsAttr[TP]);
     int transSize = transProfile.size();
 
@@ -150,9 +150,9 @@ void OpalMultipoleTStraight::update() {
     multT->setEntranceAngle(Attributes::getReal(itsAttr[EANGLE]));
 
     StraightGeometry &geometry = multT->getGeometry();
-    
+
     geometry = StraightGeometry(2 * boundingBoxLength);
-    
+
     for(int comp = 0; comp < transSize; comp++) {
         multT->setTransProfile(comp, transProfile[comp]);
     }

--- a/src/Elements/OpalMultipoleTStraight.h
+++ b/src/Elements/OpalMultipoleTStraight.h
@@ -35,7 +35,7 @@
 
 /** OpalMultipoleTStraight provides user interface information for the MultipoleTStraight object
  *
- *  Defines input parameters 
+ *  Defines input parameters
  */
 class OpalMultipoleTStraight: public OpalElement {
 
@@ -44,17 +44,17 @@ public:
     // The attributes of class OpalMultipoleTStraight
     enum {
         TP = COMMON,     // Transverse field components
-	RFRINGE,         // Length of right fringe field
-	LFRINGE,         // Length of left fringe field
-	HAPERT,          // Aperture horizontal dimension
-	VAPERT,          // Aperture vertical dimension
-	MAXFORDER,       // Maximum order in the field expansion
-	ROTATION,        // Rotation angle about central axis for skew elements
-	EANGLE,          // Entrance angle
+        RFRINGE,         // Length of right fringe field
+        LFRINGE,         // Length of left fringe field
+        HAPERT,          // Aperture horizontal dimension
+        VAPERT,          // Aperture vertical dimension
+        MAXFORDER,       // Maximum order in the field expansion
+        ROTATION,        // Rotation angle about central axis for skew elements
+        EANGLE,          // Entrance angle
         BBLENGTH,        // Distance between centre of magnet and entrance
-	SIZE             // size of the enum
+        SIZE             // size of the enum
     };
-    
+
     /** Default constructor initialises UI parameters. */
     OpalMultipoleTStraight();
 
@@ -85,8 +85,3 @@ public:
 };
 
 #endif
-   
- 
-  
-
-

--- a/src/Elements/OpalQuadrupole.h
+++ b/src/Elements/OpalQuadrupole.h
@@ -36,7 +36,7 @@ public:
         DK1,          // The normal quadupole coefficient error.
         K1S,          // The skew quadrupole coefficient.
         DK1S,         // The skew quadrupole coefficient error.
-        NSLICES,	  // The number of slices / steps per element for map tracking
+        NSLICES,      // The number of slices / steps per element for map tracking
         SIZE
     };
 

--- a/src/Match/Match.cpp
+++ b/src/Match/Match.cpp
@@ -61,10 +61,10 @@ void Match::deleteVariable(const std::string &name) {
     for(VarList::iterator var = theVariables.begin();
         var != theVariables.end();) { // for loop without increment
         if((*var)->getName() == name) {
-	  var = theVariables.erase(var); // new value: one after the erased element
-	} else {
-	  ++var;
-	}
+            var = theVariables.erase(var); // new value: one after the erased element
+        } else {
+            ++var;
+        }
     }
 }
 

--- a/src/OpalParser/OpalParser.cpp
+++ b/src/OpalParser/OpalParser.cpp
@@ -332,12 +332,12 @@ void OpalParser::parseDefine(Statement &stat) const {
         Object *classObject = find(clsName);
 
         if(classObject == 0) {
-	  if (clsName == "SURFACEPHYSICS")
+            if (clsName == "SURFACEPHYSICS")
               throw ParseError("OpalParser::parseDefine()",
-			       "The object \"" + clsName + "\" is changed to \"PARTICLEMATTERINTERACTION\".");
-	  else
-	      throw ParseError("OpalParser::parseDefine()",
-			       "The object \"" + clsName + "\" is unknown.");
+                               "The object \"" + clsName + "\" is changed to \"PARTICLEMATTERINTERACTION\".");
+            else
+                throw ParseError("OpalParser::parseDefine()",
+                                 "The object \"" + clsName + "\" is unknown.");
         }
 
         Object *copy = 0;
@@ -591,7 +591,7 @@ Statement *OpalParser::readStatement(TokenStream *is) const {
         ERRORMSG("     " << *stat <<"    a" << what << '\n' << endl);
 
         stat = readStatement(is);
-	exit(1);
+        exit(1);
     }
 
     return stat;
@@ -619,7 +619,7 @@ void OpalParser::run() const {
             } while (pos != std::string::npos);
             errorMsg << "    " << what << endl;
 
-	    MPI_Abort(MPI_COMM_WORLD, -100);
+            MPI_Abort(MPI_COMM_WORLD, -100);
         }
 
         delete stat;

--- a/src/Solvers/ArbitraryDomain.cpp
+++ b/src/Solvers/ArbitraryDomain.cpp
@@ -25,9 +25,9 @@
 #include <math.h>
 
 ArbitraryDomain::ArbitraryDomain( BoundaryGeometry * bgeom,
-   	                          Vector_t nr,
-	                          Vector_t hr,
-	                          std::string interpl){
+                                  Vector_t nr,
+                                  Vector_t hr,
+                                  std::string interpl){
     bgeom_m  = bgeom;
     minCoords_m = bgeom->getmincoords();
     maxCoords_m = bgeom->getmaxcoords();
@@ -100,8 +100,8 @@ void ArbitraryDomain::compute(Vector_t hr){
                     rotateZAxisWithQuaternion(dir, localToGlobalQuaternion_m);
                     if (bgeom_m->intersectRayBoundary(P, dir, I)) {
                         I -= geomCentroid_m;
-  		        rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectHiZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
+                        rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectHiZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "zdir=+1 " << dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -110,8 +110,8 @@ void ArbitraryDomain::compute(Vector_t hr){
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)) {
                         I -= geomCentroid_m;
-			rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
+                        rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "zdir=-1 " << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -131,8 +131,8 @@ void ArbitraryDomain::compute(Vector_t hr){
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)) {
                         I -= geomCentroid_m;
-			rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoY.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[1]));
+                        rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoY.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[1]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "ydir=-1" << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -142,8 +142,8 @@ void ArbitraryDomain::compute(Vector_t hr){
                     rotateXAxisWithQuaternion(dir, localToGlobalQuaternion_m);
                     if (bgeom_m->intersectRayBoundary(P, dir, I)) {
                         I -= geomCentroid_m;
-			rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectHiX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
+                        rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectHiX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "xdir=+1 " << dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -152,8 +152,8 @@ void ArbitraryDomain::compute(Vector_t hr){
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)){
                         I -= geomCentroid_m;
-			rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
+                        rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "xdir=-1 " << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -175,11 +175,11 @@ void ArbitraryDomain::compute(Vector_t hr){
     for (idz = 0; idz < nr[2]; idz++) {
         for (idy = 0; idy < nr[1]; idy++) {
             for (idx = 0; idx < nr[0]; idx++) {
-		if (isInside(idx, idy, idz)) {
+                if (isInside(idx, idy, idz)) {
                     IdxMap[toCoordIdx(idx, idy, idz)] = id;
                     CoordMap[id] = toCoordIdx(idx, idy, idz);
                     id++;
-		}
+                }
             }
         }
     }
@@ -264,10 +264,10 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
                     dir = Vector_t(0, 0, 1);
 
                     if (bgeom_m->intersectRayBoundary(P, dir, I)) {
-			//I -= geomCentroid_m;
-			//I -= globalMeanR_m;
+                        //I -= geomCentroid_m;
+                        //I -= globalMeanR_m;
                         //rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectHiZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
+                        IntersectHiZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "zdir=+1 " << dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -275,10 +275,10 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
                     }
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)) {
-			//I -= geomCentroid_m;
-			//I -= globalMeanR_m;
-			//rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
+                        //I -= geomCentroid_m;
+                        //I -= globalMeanR_m;
+                        //rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoZ.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[2]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "zdir=-1 " << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -300,10 +300,10 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
                     }
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)) {
-			//I -= geomCentroid_m;
-			//I -= globalMeanR_m;
-			//rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoY.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[1]));
+                        //I -= geomCentroid_m;
+                        //I -= globalMeanR_m;
+                        //rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoY.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[1]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "ydir=-1" << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -314,10 +314,10 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
                     dir = Vector_t(1, 0, 0);
 
                     if (bgeom_m->intersectRayBoundary(P, dir, I)) {
-			//I -= geomCentroid_m;
-			//I -= globalMeanR_m;
-			//rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectHiX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
+                        //I -= geomCentroid_m;
+                        //I -= globalMeanR_m;
+                        //rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectHiX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "xdir=+1 " << dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -325,10 +325,10 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
                     }
 
                     if (bgeom_m->intersectRayBoundary(P, -dir, I)){
-		        //I -= geomCentroid_m;
-			//I -= globalMeanR_m;
-			//rotateWithQuaternion(I, globalToLocalQuaternion_m);
-       	      		IntersectLoX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
+                        //I -= geomCentroid_m;
+                        //I -= globalMeanR_m;
+                        //rotateWithQuaternion(I, globalToLocalQuaternion_m);
+                        IntersectLoX.insert(std::pair< std::tuple<int, int, int>, double >(pos, I[0]));
                     } else {
 #ifdef DEBUG_INTERSECT_RAY_BOUNDARY
                         *gmsg << "xdir=-1 " << -dir << " x,y,z= " << idx << "," << idy << "," << idz << " P=" << P <<" I=" << I << endl;
@@ -388,7 +388,7 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
     for(int idz = localId[2].first() - zGhostOffsetLeft; idz <= localId[2].last() + zGhostOffsetRight; idz++) {
         for(int idy = 0; idy < nr[1]; idy++) {
             for(int idx = 0; idx < nr[0]; idx++) {
-		if(isInside(idx, idy, idz)) {
+                if(isInside(idx, idy, idz)) {
                     IdxMap[toCoordIdx(idx, idy, idz)] = index;
                     CoordMap[index] = toCoordIdx(idx, idy, idz);
                     index++;
@@ -538,9 +538,9 @@ void ArbitraryDomain::constantInterpolation(int idx, int idy, int idz, double& W
         S = 0.0;
 
     if(!isInside(idx,idy,idz-1))
-	F = 0.0;
+        F = 0.0;
     if(!isInside(idx,idy,idz+1))
-	B = 0.0;
+        B = 0.0;
 }
 
 void ArbitraryDomain::linearInterpolation(int idx, int idy, int idz, double& W, double& E, double& S, double& N, double& F, double& B, double& C, double &scaleFactor)
@@ -663,10 +663,10 @@ void ArbitraryDomain::getNeighbours(int idx, int idy, int idz, int &W, int &E, i
         S = -1;
 
     if(!isInside(idx,idy,idz-1))
-	F = -1;
+        F = -1;
 
     if(!isInside(idx,idy,idz+1))
-	B = -1;
+        B = -1;
 
 }
 

--- a/src/Solvers/BoxCornerDomain.cpp
+++ b/src/Solvers/BoxCornerDomain.cpp
@@ -39,7 +39,7 @@ BoxCornerDomain::BoxCornerDomain(double A, double B, double C, double Length, do
       std::string file("boxcorner.dat");
       os_m.open(file.c_str());
       if(os_m.bad()) {
-	*gmsg << "Unable to open output file " <<  file << endl;
+          *gmsg << "Unable to open output file " <<  file << endl;
       }
       //os_m << "# ...." << endl;
     }
@@ -73,7 +73,7 @@ void BoxCornerDomain::compute(Vector_t hr){
     actBMax_m = std::max(bL,bH);
 
     INFOMSG(" BoxCorner L= " << Length_m << " L1= " << L1_m << " L2= " << L2_m << " A= " << A_m << " B= " << B_m << " C= " << C_m
-	    << " bL= " << bL << " bH= " << bH <<  " actBMin= " << actBMin_m << " actBMax=max(bL,bH)= " << actBMax_m << endl);
+            << " bL= " << bL << " bH= " << bH <<  " actBMin= " << actBMin_m << " actBMax=max(bL,bH)= " << actBMax_m << endl);
 
     //reset number of points inside domain
 

--- a/src/Solvers/BoxCornerDomain.h
+++ b/src/Solvers/BoxCornerDomain.h
@@ -20,20 +20,20 @@
     A_m and B_m are the half apperture of the box
 
 
-                                     / (A_m,B_m)       
+                                     / (A_m,B_m)
                                     /
                                    /
                                   /
     L1_m                         /
-------------      --------------+ (-A_m,B_m)       
+------------      --------------+ (-A_m,B_m)
            | L2_m |             |
-        C_m|      |             | 
+        C_m|      |             |
            |------|             |      /
-	 .....                  |     /
+         .....                  |     /
 (0,0)---.......-----------------+    /
          .....                  |   /
    z                            |  /
-   |                            | / 
+   |                            | /
 --------------------------------+/ (-A_m,-B_m)
 
             Length_m
@@ -107,7 +107,7 @@ public:
     double getYRangeMin() { return  -B_m;} // actBMin_m; }
     double getYRangeMax() { return  B_m; } // actBMax_m; }
     double getZRangeMin() { return  L1_m;}
-    double getZRangeMax() { return  L1_m+L2_m; } 
+    double getZRangeMax() { return  L1_m+L2_m; }
 
 
     //TODO: ?
@@ -142,7 +142,7 @@ private:
     /// the maximal hight of the box
     double B_m;
 
-    
+
     /// because the geometry can change in the y direction
     double actBMin_m;
 

--- a/src/Solvers/BoxLibSolvers/FMGPoissonSolver.cpp
+++ b/src/Solvers/BoxLibSolvers/FMGPoissonSolver.cpp
@@ -15,7 +15,7 @@ FMGPoissonSolver::FMGPoissonSolver(AmrBoxLib* itsAmrObject_p)
         bc_m[2 * d]     = MGT_BC_DIR;
         bc_m[2 * d + 1] = MGT_BC_DIR;
     }
-    
+
     this->initParameters_m();
 }
 
@@ -41,17 +41,17 @@ void FMGPoissonSolver::solve(AmrScalarFieldContainer_t& rho,
             }
         }
     }
-    
+
     amrex::Vector< AmrScalarFieldContainer_t > grad_phi_edge(rho.size());
-    
+
     for (int lev = baseLevel; lev <= finestLevel ; ++lev) {
         const AmrProcMap_t& dmap = rho[lev]->DistributionMap();
-	grad_phi_edge[lev].resize(AMREX_SPACEDIM);
-        
+        grad_phi_edge[lev].resize(AMREX_SPACEDIM);
+
         for (int n = 0; n < AMREX_SPACEDIM; ++n) {
-	    AmrGrid_t ba = rho[lev]->boxArray();
+            AmrGrid_t ba = rho[lev]->boxArray();
             grad_phi_edge[lev][n].reset(new AmrField_t(ba.surroundingNodes(n), dmap, 1, 1));
-	    grad_phi_edge[lev][n]->setVal(0.0, 1);
+            grad_phi_edge[lev][n]->setVal(0.0, 1);
         }
     }
 
@@ -61,7 +61,7 @@ void FMGPoissonSolver::solve(AmrScalarFieldContainer_t& rho,
             efield[i][j]->setVal(0.0, 1);
         }
     }
-    
+
     double residNorm = this->solveWithF90_m(amrex::GetVecOfPtrs(rho),
                                             amrex::GetVecOfPtrs(phi),
                                             amrex::GetVecOfVecOfPtrs(grad_phi_edge),
@@ -76,13 +76,13 @@ void FMGPoissonSolver::solve(AmrScalarFieldContainer_t& rho,
         throw OpalException("FMGPoissonSolver::solve()",
                             "Multigrid solver did not converge. " + ss.str());
     }
-    
+
     for (int lev = baseLevel; lev <= finestLevel; ++lev) {
         for (int j = 0; j < AMREX_SPACEDIM; ++j) {
             amrex::average_face_to_cellcenter(*(efield[lev][j].get()),
                                               amrex::GetVecOfConstPtrs(grad_phi_edge[lev]),
                                               geom[lev]);
-        
+
             efield[lev][j]->FillBoundary(0, 1, geom[lev].periodicity());
             // we need also minus sign due to \vec{E} = - \nabla\phi
             efield[lev][j]->mult(-1.0, 0, 1);
@@ -134,52 +134,52 @@ void FMGPoissonSolver::initParameters_m() {
     /* The information about the parameters is copied from the
      * BoxLib documentation chapter 5 on linear solvers and from
      * the code itself.
-     * 
+     *
      * Some paramters that have to be given to the solver using
      * AMReX_ParmParse.
      * "doc" tells how the variable is called in
      *  - amrex/Src/LinearSolvers/F_MG/cc_mg_cpp.f90
      *  - amrex/Src/LinearSolvers/F_MG/mg_tower.f90 (conains defaults)
      *  - amrex/Src/LinearSolvers/C_to_F_MG/AMReX_MGT_Solver.cpp
-     * 
+     *
      */
-    
+
     amrex::ParmParse pp_mg("mg");
-    
+
     // maximum number of multigrid cycles (doc: max_iter)
     pp_mg.add("maxiter", 200);
-    
+
     // maximum number of iterations for the bottom solver (doc: bottom_max_iter)
     pp_mg.add("maxiter_b", 200);
-    
+
     // number of smoothings at each level on the way DOWN the V-cycle (doc: nu1)
     pp_mg.add("nu_1", 2);
-    
+
     // number of smoothings at each level on the way UP the V-cycle (doc: nu2)
     pp_mg.add("nu_2", 2);
-    
+
     // number of smoothing before and after the bottom solver (doc: nub)
     pp_mg.add("nu_b", 0);
-    
+
     // number of smoothing ... ?
     pp_mg.add("nu_f", 8);
-    
+
     // verbosity of the multigrid solver. Higher numbers give more verbosity (doc: verbose)
     pp_mg.add("v"   , 0);
-    
-    
+
+
     // see amrex/Src/LinearSolvers/C_to_F_MG/AMReX_MGT_Solver.cpp
     pp_mg.add("usecg", 1);
-    
+
     // bottom_solver_eps, see amrex/Src/LinearSolvers/C_to_F_MG/AMReX_MGT_Solver.cpp
     pp_mg.add("rtol_b", 0.0001);
-    
+
     // see amrex/Src/LinearSolvers/C_to_F_MG/AMReX_MGT_Solver.cpp
     pp_mg.add("cg_solver", 1);
-    
-    // maximum number of levels (max_nlevel) 
+
+    // maximum number of levels (max_nlevel)
     pp_mg.add("numLevelsMAX", 1024);
-    
+
     /* MG_SMOOTHER_GS_RB  = 1   (red-black Gauss-Seidel)
      * MG_SMOOTHER_JACOBI = 2   (Jacobi)
      * MG_SMOOTHER_MINION_CROSS = 5
@@ -187,40 +187,40 @@ void FMGPoissonSolver::initParameters_m() {
      * MG_SMOOTHER_EFF_RB = 7
      */
     pp_mg.add("smoother", 1);
-    
+
     /* The type of multigrid to do
-     * 
+     *
      * MG_FCycle = 1    (F, full multigrid)
      * MG_WCycle = 2    (W-cycles)
      * MG_VCycle = 3    (V-cycles)
      * MG_FVCycle = 4   (F + V cycles)
      */
     pp_mg.add("cycle_type", 1);
-    
+
     /* the type of bottom solver to use
-     * 
+     *
      * BiCG:    biconjugate gradient stabilized (bottom_solver = 1)
      * CG:      conjugate gradient method (bottom_solver = 2)
      * CABiCG:  (bottom_solver = 3)
      * special: bottom_solver = 4
-     * 
+     *
      * The special bottom solver extends the range of the multigrid coarsening
      * by aggregating coarse grids on the original mesh together and further coarsening.
-     * 
+     *
      * if use_cg == 1 && cg_solver == 0 --> CG
      * if use_cg == 1 && cg_solver == 1 --> BiCG
      * if use_cg == 1 && cg_solver == 2 --> CABiCG
      * if use_cg == 0                   --> CABiCG
      */
-    pp_mg.add("bottom_solver", 1);    
-    
+    pp_mg.add("bottom_solver", 1);
+
     // verbosity of the bottom solver. Higher numbers give more verbosity (doc: cg_verbose)
     amrex::ParmParse pp_cg("cg");
     pp_cg.add("v", 0);
-    
-    
+
+
     /* Additional parameters that can't be set by ParmParse:
-     * 
+     *
      *      - max_bottom_nlevel = 3 (additional coarsening if you use bottom_solver == 4)
      *      - min_width = 2 (minimum size of grid at coarsest multigrid level)
      *      - max_L0_growth = -1
@@ -238,38 +238,38 @@ double FMGPoissonSolver::solveWithF90_m(const AmrFieldContainer_pt& rho,
                                         int finestLevel)
 {
     int nlevs = finestLevel - baseLevel + 1;
-    
+
     GeomContainer_t geom_p(nlevs);
     AmrFieldContainer_pt rho_p(nlevs);
     AmrFieldContainer_pt phi_p(nlevs);
-    
+
     for (int ilev = 0; ilev < nlevs; ++ilev) {
         geom_p[ilev] = geom[ilev + baseLevel];
         rho_p[ilev]  = rho[ilev + baseLevel];
         phi_p[ilev]  = phi[ilev + baseLevel];
     }
-    
+
     //FIXME Refinement ratio
     amrex::IntVect crse_ratio = (baseLevel == 0) ?
         amrex::IntVect::TheZeroVector() : itsAmrObject_mp->refRatio(0);
 
     amrex::FMultiGrid fmg(geom_p, baseLevel, crse_ratio);
-    
+
     if (baseLevel == 0)
         fmg.set_bc(bc_m, *phi_p[baseLevel]);
     else
         fmg.set_bc(bc_m, *phi_p[baseLevel-1], *phi_p[baseLevel]);
-    
+
     /* (alpha * a - beta * (del dot b grad)) phi = rho
      * (b = 1)
-     * 
+     *
      * The function call set_const_gravity_coeffs() sets alpha = 0.0
      * and beta = -1 (in MGT_Solver::set_const_gravity_coeffs)
-     * 
+     *
      * --> (del dot grad) phi = rho
      */
     fmg.set_const_gravity_coeffs();
-    
+
     // order of approximation at Dirichlet boundaries
     fmg.set_maxorder(3);
 
@@ -277,12 +277,12 @@ double FMGPoissonSolver::solveWithF90_m(const AmrFieldContainer_pt& rho,
     int need_grad_phi = 1;
 
     double residNorm = fmg.solve(phi_p, rho_p, reltol_m, abstol_m, always_use_bnorm, need_grad_phi);
-    
+
     for (int ilev = 0; ilev < nlevs; ++ilev) {
         int amr_level = ilev + baseLevel;
         fmg.get_fluxes(grad_phi_edge[amr_level], ilev);
     }
-    
+
     return residNorm;
 }
 
@@ -298,7 +298,7 @@ void FMGPoissonSolver::interpolate_m(AmrScalarFieldContainer_t& phi,
     int hi_bc[] = {INT_DIR, INT_DIR, INT_DIR};
     amrex::Vector<amrex::BCRec> bcs(1, amrex::BCRec(lo_bc, hi_bc));
     amrex::PCInterp mapper;
-    
+
     std::unique_ptr<AmrField_t> tmp;
 
     for (int lev = 1; lev <= finestLevel; ++lev) {
@@ -306,7 +306,7 @@ void FMGPoissonSolver::interpolate_m(AmrScalarFieldContainer_t& phi,
         const AmrProcMap_t& dm = phi[lev]->DistributionMap();
         tmp.reset(new AmrField_t(ba, dm, 1, 0));
         tmp->setVal(0.0);
-    
+
         amrex::InterpFromCoarseLevel(*tmp, 0.0, *phi[lev-1],
                                      0, 0, 1, geom[lev-1], geom[lev],
                                      cphysbc, fphysbc,
@@ -315,7 +315,7 @@ void FMGPoissonSolver::interpolate_m(AmrScalarFieldContainer_t& phi,
         phi[lev]->plus(*tmp, 0, 1, 0);
         phi[lev-1]->mult(l0norm, 0, 1);
     }
-    
+
     phi[finestLevel]->mult(l0norm, 0, 1);
 }
 */

--- a/src/Solvers/EllipticDomain.cpp
+++ b/src/Solvers/EllipticDomain.cpp
@@ -48,7 +48,7 @@ EllipticDomain::EllipticDomain(BoundaryGeometry *bgeom, Vector_t nr, std::string
     SemiMajor = bgeom->getA();
     SemiMinor = bgeom->getB();
     setMinMaxZ(bgeom->getS(), bgeom->getLength());
-    Vector_t hr_m; 
+    Vector_t hr_m;
     hr_m[0] = (getXRangeMax()-getXRangeMin())/nr[0];
     hr_m[1] = (getYRangeMax()-getYRangeMin())/nr[1];
     hr_m[2] = (getZRangeMax()-getZRangeMin())/nr[2];
@@ -122,27 +122,27 @@ void EllipticDomain::compute(Vector_t hr){
                 pos = x * hr[0] - mx;
                 if (pos <= -SemiMajor || pos >= SemiMajor)
                 {
-                	IntersectYDir.insert(std::pair<int, double>(x, 0));
-	                IntersectYDir.insert(std::pair<int, double>(x, 0));
-		}else{
-                	yd = std::abs(sqrt(sminsq - sminsq * pos * pos / smajsq)); // + 0.5*nr[1]*hr[1]);
-	                IntersectYDir.insert(std::pair<int, double>(x, yd));
-       		        IntersectYDir.insert(std::pair<int, double>(x, -yd));
-		}
+                    IntersectYDir.insert(std::pair<int, double>(x, 0));
+                    IntersectYDir.insert(std::pair<int, double>(x, 0));
+                }else{
+                    yd = std::abs(sqrt(sminsq - sminsq * pos * pos / smajsq)); // + 0.5*nr[1]*hr[1]);
+                    IntersectYDir.insert(std::pair<int, double>(x, yd));
+                    IntersectYDir.insert(std::pair<int, double>(x, -yd));
+                }
 
             }
 
             for(y = 0; y < nr[1]; y++) {
                 pos = y * hr[1] - my;
-		if (pos <= -SemiMinor || pos >= SemiMinor)
+                if (pos <= -SemiMinor || pos >= SemiMinor)
                 {
-                	IntersectXDir.insert(std::pair<int, double>(y, 0));
-	                IntersectXDir.insert(std::pair<int, double>(y, 0));
-		}else{
-	                xd = std::abs(sqrt(smajsq - smajsq * pos * pos / sminsq)); // + 0.5*nr[0]*hr[0]);
-        	        IntersectXDir.insert(std::pair<int, double>(y, xd));
-               		IntersectXDir.insert(std::pair<int, double>(y, -xd));
-		}
+                    IntersectXDir.insert(std::pair<int, double>(y, 0));
+                    IntersectXDir.insert(std::pair<int, double>(y, 0));
+                }else{
+                    xd = std::abs(sqrt(smajsq - smajsq * pos * pos / sminsq)); // + 0.5*nr[0]*hr[0]);
+                    IntersectXDir.insert(std::pair<int, double>(y, xd));
+                    IntersectXDir.insert(std::pair<int, double>(y, -xd));
+                }
             }
     }
 }
@@ -198,27 +198,27 @@ void EllipticDomain::compute(Vector_t hr, NDIndex<3> localId){
                 pos = x * hr[0] - mx;
                 if (pos <= -SemiMajor || pos >= SemiMajor)
                 {
-                	IntersectYDir.insert(std::pair<int, double>(x, 0));
-	                IntersectYDir.insert(std::pair<int, double>(x, 0));
-		}else{
-                	yd = std::abs(sqrt(sminsq - sminsq * pos * pos / smajsq)); // + 0.5*nr[1]*hr[1]);
-	                IntersectYDir.insert(std::pair<int, double>(x, yd));
-       		        IntersectYDir.insert(std::pair<int, double>(x, -yd));
-		}
+                    IntersectYDir.insert(std::pair<int, double>(x, 0));
+                    IntersectYDir.insert(std::pair<int, double>(x, 0));
+                }else{
+                    yd = std::abs(sqrt(sminsq - sminsq * pos * pos / smajsq)); // + 0.5*nr[1]*hr[1]);
+                    IntersectYDir.insert(std::pair<int, double>(x, yd));
+                    IntersectYDir.insert(std::pair<int, double>(x, -yd));
+                }
 
             }
 
             for(y = localId[0].first(); y < localId[1].last(); y++) {
                 pos = y * hr[1] - my;
-		if (pos <= -SemiMinor || pos >= SemiMinor)
+                if (pos <= -SemiMinor || pos >= SemiMinor)
                 {
-                	IntersectXDir.insert(std::pair<int, double>(y, 0));
-	                IntersectXDir.insert(std::pair<int, double>(y, 0));
-		}else{
-	                xd = std::abs(sqrt(smajsq - smajsq * pos * pos / sminsq)); // + 0.5*nr[0]*hr[0]);
-        	        IntersectXDir.insert(std::pair<int, double>(y, xd));
-               		IntersectXDir.insert(std::pair<int, double>(y, -xd));
-		}
+                    IntersectXDir.insert(std::pair<int, double>(y, 0));
+                    IntersectXDir.insert(std::pair<int, double>(y, 0));
+                }else{
+                    xd = std::abs(sqrt(smajsq - smajsq * pos * pos / sminsq)); // + 0.5*nr[0]*hr[0]);
+                    IntersectXDir.insert(std::pair<int, double>(y, xd));
+                    IntersectXDir.insert(std::pair<int, double>(y, -xd));
+                }
             }
     }
 }

--- a/src/Solvers/FFTPoissonSolver.cpp
+++ b/src/Solvers/FFTPoissonSolver.cpp
@@ -244,37 +244,37 @@ void FFTPoissonSolver::initializeFields() {
 
       if (Ippl::myNode() == 0) {
 
-	//create stream for greens function
-	dksbase.createStream(streamGreens);
-	dksbase.createStream(streamFFT);
+          //create stream for greens function
+          dksbase.createStream(streamGreens);
+          dksbase.createStream(streamFFT);
 
-	//create fft plans for multiple reuse
-	int dimsize[3] = {2*nr_m[0], 2*nr_m[1], 2*nr_m[2]};
+          //create fft plans for multiple reuse
+          int dimsize[3] = {2*nr_m[0], 2*nr_m[1], 2*nr_m[2]};
 
-	dksbase.setupFFT(3, dimsize);
+          dksbase.setupFFT(3, dimsize);
 
-	//allocate memory
-	int sizegreen = tmpgreen_m.getLayout().getDomain().size();
-	int sizerho2_m = rho2_m.getLayout().getDomain().size();
-	int sizecomp = grntr_m.getLayout().getDomain().size();
+          //allocate memory
+          int sizegreen = tmpgreen_m.getLayout().getDomain().size();
+          int sizerho2_m = rho2_m.getLayout().getDomain().size();
+          int sizecomp = grntr_m.getLayout().getDomain().size();
 
-	tmpgreen_ptr = dksbase.allocateMemory<double>(sizegreen, dkserr);
-	rho2_m_ptr = dksbase.allocateMemory<double>(sizerho2_m, dkserr);
-	rho2real_m_ptr = dksbase.allocateMemory<double>(sizerho2_m, dkserr);
+          tmpgreen_ptr = dksbase.allocateMemory<double>(sizegreen, dkserr);
+          rho2_m_ptr = dksbase.allocateMemory<double>(sizerho2_m, dkserr);
+          rho2real_m_ptr = dksbase.allocateMemory<double>(sizerho2_m, dkserr);
 
-	grntr_m_ptr = dksbase.allocateMemory< std::complex<double>  >(sizecomp, dkserr);
-	rho2tr_m_ptr = dksbase.allocateMemory< std::complex<double> > (sizecomp, dkserr);
+          grntr_m_ptr = dksbase.allocateMemory< std::complex<double>  >(sizecomp, dkserr);
+          rho2tr_m_ptr = dksbase.allocateMemory< std::complex<double> > (sizecomp, dkserr);
 
-	//send rho2real_m_ptr to other mpi processes
-	//send streamFFT to other processes
-	for (int p = 1; p < Ippl::getNodes(); p++) {
-	  dksbase.sendPointer( rho2real_m_ptr, p, Ippl::getComm() );
-	}
+          //send rho2real_m_ptr to other mpi processes
+          //send streamFFT to other processes
+          for (int p = 1; p < Ippl::getNodes(); p++) {
+              dksbase.sendPointer( rho2real_m_ptr, p, Ippl::getComm() );
+          }
       } else {
-	//create stream for FFT data transfer
-	dksbase.createStream(streamFFT);
-	//receive pointer
-	rho2real_m_ptr = dksbase.receivePointer(0, Ippl::getComm(), dkserr);
+          //create stream for FFT data transfer
+          dksbase.createStream(streamFFT);
+          //receive pointer
+          rho2real_m_ptr = dksbase.receivePointer(0, Ippl::getComm(), dkserr);
       }
     }
 
@@ -529,14 +529,14 @@ void FFTPoissonSolver::integratedGreensFunctionDKS() {
    */
   NDIndex<3> idx =  layout4_m->getDomain();
   dksbase.callGreensIntegral(tmpgreen_ptr, idx[0].length(), idx[1].length(), idx[2].length(),
-			     nr_m[0]+1, nr_m[1]+1, hr_m[0], hr_m[1], hr_m[2], streamGreens);
+                             nr_m[0]+1, nr_m[1]+1, hr_m[0], hr_m[1], hr_m[2], streamGreens);
 
   Index I = nr_m[0] + 1;
   Index J = nr_m[1] + 1;
   Index K = nr_m[2] + 1;
 
   dksbase.callGreensIntegration(rho2_m_ptr, tmpgreen_ptr, nr_m[0]+1, nr_m[1]+1, nr_m[2]+1,
-				streamGreens);
+                                streamGreens);
 
   dksbase.callMirrorRhoField(rho2_m_ptr, nr_m[0], nr_m[1], nr_m[2], streamGreens);
 #endif

--- a/src/Solvers/MGPoissonSolver.cpp
+++ b/src/Solvers/MGPoissonSolver.cpp
@@ -102,7 +102,7 @@ MGPoissonSolver::MGPoissonSolver ( PartBunch *beam,
     if(currentGeometry->getFilename() == "") {
         if(currentGeometry->getTopology() == "ELLIPTIC"){
             bp = new EllipticDomain(currentGeometry, orig_nr_m, hr_m, interpl);
-	} else if (currentGeometry->getTopology() == "BOXCORNER") {
+        } else if (currentGeometry->getTopology() == "BOXCORNER") {
             bp = new BoxCornerDomain(currentGeometry->getA(), currentGeometry->getB(), currentGeometry->getC(), currentGeometry->getLength(),currentGeometry->getL1(), currentGeometry->getL2(), orig_nr_m, hr_m, interpl);
             bp->compute(itsBunch_m->get_hr());
         } else {
@@ -119,7 +119,7 @@ MGPoissonSolver::MGPoissonSolver ( PartBunch *beam,
                                 "Please set PARFFTX=FALSE, PARFFTY=FALSE, PARFFTT=TRUE in \n"
                                 "the definition of the field solver in the input file.\n");
         }
-	bp = new ArbitraryDomain(currentGeometry, orig_nr_m, hr_m, interpl);
+        bp = new ArbitraryDomain(currentGeometry, orig_nr_m, hr_m, interpl);
     }
 
     Map = 0;
@@ -239,7 +239,7 @@ void MGPoissonSolver::extrapolateLHS() {
         }
         *LHS = *(*P)(0);
      } else
-	    throw OpalException("MGPoissonSolver", "Invalid number of old LHS: " + std::to_string(OldLHS.size()));
+        throw OpalException("MGPoissonSolver", "Invalid number of old LHS: " + std::to_string(OldLHS.size()));
 }
 
 
@@ -300,8 +300,8 @@ void MGPoissonSolver::computePotential(Field_t &rho, Vector_t hr) {
     }
     for (int idz = localId[2].first(); idz <= localId[2].last(); idz++) {
         for (int idy = localId[1].first(); idy <= localId[1].last(); idy++) {
-    	    for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
-		    if (bp->isInside(idx, idy, idz))
+            for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
+                if (bp->isInside(idx, idy, idz))
                         RHS->Values()[id++] = 4*M_PI*rho[idx][idy][idz].get()/scaleFactor;
             }
         }
@@ -402,7 +402,7 @@ void MGPoissonSolver::computePotential(Field_t &rho, Vector_t hr) {
     rho = 0.0;
     for (int idz = localId[2].first(); idz <= localId[2].last(); idz++) {
         for (int idy = localId[1].first(); idy <= localId[1].last(); idy++) {
-    	    for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
+            for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
                   NDIndex<3> l(Index(idx, idx), Index(idy, idy), Index(idz, idz));
                   if (bp->isInside(idx, idy, idz))
                      rho.localElement(l) = LHS->Values()[id++]*scaleFactor;
@@ -426,8 +426,8 @@ void MGPoissonSolver::redistributeWithRCB(NDIndex<3> localId) {
 
     for (int idz = localId[2].first(); idz <= localId[2].last(); idz++) {
         for (int idy = localId[1].first(); idy <= localId[1].last(); idy++) {
-    	    for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
-		    if (bp->isInside(idx, idy, idz))
+            for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
+                if (bp->isInside(idx, idy, idz))
                     numMyGridPoints++;
              }
         }
@@ -444,8 +444,8 @@ void MGPoissonSolver::redistributeWithRCB(NDIndex<3> localId) {
 
     for (int idz = localId[2].first(); idz <= localId[2].last(); idz++) {
         for (int idy = localId[1].first(); idy <= localId[1].last(); idy++) {
-    	    for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
-		    if (bp->isInside(idx, idy, idz)) {
+            for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
+                if (bp->isInside(idx, idy, idz)) {
                     v[0] = (double)idx;
                     v[stride] = (double)idy;
                     v[stride2] = (double)idz;
@@ -486,12 +486,12 @@ void MGPoissonSolver::IPPLToMap3D(NDIndex<3> localId) {
     for (int idz = localId[2].first(); idz <= localId[2].last(); idz++) {
         for (int idy = localId[1].first(); idy <= localId[1].last(); idy++) {
             for (int idx = localId[0].first(); idx <= localId[0].last(); idx++) {
-		    if (bp->isInside(idx, idy, idz)) {
+                if (bp->isInside(idx, idy, idz)) {
                     MyGlobalElements.push_back(bp->getIdx(idx, idy, idz));
                     NumMyElements++;
                 }
             }
-	}
+        }
     }
     Map = new Epetra_Map(-1, NumMyElements, &MyGlobalElements[0], 0, Comm);
 }
@@ -542,7 +542,7 @@ void MGPoissonSolver::ComputeStencil(Vector_t hr, Teuchos::RCP<Epetra_Vector> RH
             Values[NumEntries++] = BV;
         }
 
-    	// if matrix has already been filled (FillComplete()) we can only
+        // if matrix has already been filled (FillComplete()) we can only
         // replace entries
 
         if(A->Filled()) {

--- a/src/Structure/BoundaryGeometry.cpp
+++ b/src/Structure/BoundaryGeometry.cpp
@@ -660,27 +660,27 @@ public:
         double& tmin,       // tmin and tmax are unchanged, if there is
         double& tmax        // no intersection
         ) const {
-	double tmin_ = (pts[r.sign[0]][0]   - r.origin[0]) * r.inv_direction[0];
-	double tmax_ = (pts[1-r.sign[0]][0] - r.origin[0]) * r.inv_direction[0];
-	const double tymin = (pts[r.sign[1]][1]   - r.origin[1]) * r.inv_direction[1];
-	const double tymax = (pts[1-r.sign[1]][1] - r.origin[1]) * r.inv_direction[1];
-	if ( (tmin_ > tymax) || (tymin > tmax_) )
+        double tmin_ = (pts[r.sign[0]][0]   - r.origin[0]) * r.inv_direction[0];
+        double tmax_ = (pts[1-r.sign[0]][0] - r.origin[0]) * r.inv_direction[0];
+        const double tymin = (pts[r.sign[1]][1]   - r.origin[1]) * r.inv_direction[1];
+        const double tymax = (pts[1-r.sign[1]][1] - r.origin[1]) * r.inv_direction[1];
+        if ( (tmin_ > tymax) || (tymin > tmax_) )
             return 0;       // no intersection
-	if (tymin > tmin_)
+        if (tymin > tmin_)
             tmin_ = tymin;
-	if (tymax < tmax_)
+        if (tymax < tmax_)
             tmax_ = tymax;
-	const double tzmin = (pts[r.sign[2]][2]   - r.origin[2]) * r.inv_direction[2];
-	const double tzmax = (pts[1-r.sign[2]][2] - r.origin[2]) * r.inv_direction[2];
-	if ( (tmin_ > tzmax) || (tzmin > tmax_) )
+        const double tzmin = (pts[r.sign[2]][2]   - r.origin[2]) * r.inv_direction[2];
+        const double tzmax = (pts[1-r.sign[2]][2] - r.origin[2]) * r.inv_direction[2];
+        if ( (tmin_ > tzmax) || (tzmin > tmax_) )
             return 0;       // no intersection
-	if (tzmin > tmin_)
-		tmin_ = tzmin;
-	tmin = tmin_;
-	if (tzmax < tmax_)
-		tmax_ = tzmax;
-	tmax = tmax_;
-	return (tmax >= 0);
+        if (tzmin > tmin_)
+            tmin_ = tzmin;
+        tmin = tmin_;
+        if (tzmax < tmax_)
+            tmax_ = tzmax;
+        tmax = tmax_;
+        return (tmax >= 0);
     }
 
     inline bool intersect (
@@ -2115,8 +2115,8 @@ BoundaryGeometry::writeGeomToVtk (std::string fn) {
     of << "POINTS " << Points_m.size () << " float" << std::endl;
     for (unsigned int i = 0; i < Points_m.size (); i++)
         of << Points_m[i](0) << " "
-	   << Points_m[i](1) << " "
-	   << Points_m[i](2) << std::endl;
+           << Points_m[i](1) << " "
+           << Points_m[i](2) << std::endl;
     of << std::endl;
 
     of << "CELLS "
@@ -2124,17 +2124,17 @@ BoundaryGeometry::writeGeomToVtk (std::string fn) {
        << 4 * numTriangles_m << std::endl;
     for (int i = 0; i < numTriangles_m; i++)
         of << "3 "
-	   << PointID (i, 1) << " "
-	   << PointID (i, 2) << " "
-	   << PointID (i, 3) << std::endl;
+           << PointID (i, 1) << " "
+           << PointID (i, 2) << " "
+           << PointID (i, 3) << std::endl;
     of << "CELL_TYPES " << numTriangles_m << std::endl;
     for (int i = 0; i < numTriangles_m; i++)
-	of << "5" << std::endl;
+        of << "5" << std::endl;
     of << "CELL_DATA " << numTriangles_m << std::endl;
     of << "SCALARS " << "cell_attribute_data" << " float " << "1" << std::endl;
     of << "LOOKUP_TABLE " << "default" << std::endl;
     for (int i = 0; i < numTriangles_m; i++)
-	of << (float)(i) << std::endl;
+        of << (float)(i) << std::endl;
     of << std::endl;
 }
 

--- a/src/Structure/DataSink.cpp
+++ b/src/Structure/DataSink.cpp
@@ -1099,15 +1099,15 @@ void DataSink::writeSurfaceInteraction(PartBunchBase<double, 3> *beam, long long
     if(firstWriteH5Surface_m) {
         firstWriteH5Surface_m = false;
 
-	h5_prop_t props = H5CreateFileProp ();
-	MPI_Comm comm = Ippl::getComm();
-	H5SetPropFileMPIOCollective (props, &comm);
-	H5fileS_m = H5OpenFile (surfaceLossFileName_m.c_str(), H5_O_WRONLY, props);
+        h5_prop_t props = H5CreateFileProp ();
+        MPI_Comm comm = Ippl::getComm();
+        H5SetPropFileMPIOCollective (props, &comm);
+        H5fileS_m = H5OpenFile (surfaceLossFileName_m.c_str(), H5_O_WRONLY, props);
         if(H5fileS_m == (h5_file_t)H5_ERR) {
             throw OpalException("DataSink::writeSurfaceInteraction",
                                 "failed to open h5 file '" + surfaceLossFileName_m + "' for surface loss");
         }
-	H5CloseProp (props);
+        H5CloseProp (props);
 
     }
     int nTot = bg.getNumBFaces();

--- a/src/Structure/DataSink.h
+++ b/src/Structure/DataSink.h
@@ -144,7 +144,7 @@ public:
      *  \return Returns the number of the time step just written.
      */
     int writePhaseSpace_cycl(PartBunchBase<double, 3> *beam, Vector_t FDext[], double E,
-			     double refPr, double refPt, double refPz,
+                             double refPr, double refPt, double refPz,
                              double refR, double refTheta, double refZ,
                              double azimuth, double elevation, bool local);
 
@@ -233,12 +233,12 @@ public:
      */
     void writeGridLBalHeader(PartBunchBase<double, 3> *beam,
                              std::ofstream &outputFile);
-    
+
     void writeGridLBalData(PartBunchBase<double, 3> *beam,
                            std::ofstream &outputFile,
                            unsigned int pwi);
 #endif
-    
+
 
 private:
 
@@ -249,9 +249,9 @@ private:
 
     void rewindLines(const std::string &fileName, size_t numberOfLines) const;
     void replaceVersionString(const std::string &fileName) const;
-    
+
     void open_m(std::ofstream& os, const std::string& fileName) const;
-    
+
     /** \brief First write to the statistics output file.
      *
      * Initially set to std::ios::out so that SDDS format header information is written to file
@@ -277,7 +277,7 @@ private:
 
     /// Name of output file for processor memory information
     std::string memFileName_m;
-    
+
 #ifdef ENABLE_AMR
     /// Name of output file for grid load balancing information
     std::string gridLBalFileName_m;

--- a/src/Structure/FieldSolver.cpp
+++ b/src/Structure/FieldSolver.cpp
@@ -88,8 +88,8 @@ namespace {
         MAXITERS,   // max number of iterations [SAAMG only]
         PRECMODE,   // preconditioner mode [SAAMG only]
         RC,         // cutoff radius for PP interactions
-	ALPHA,      // Green’s function splitting parameter
-	EPSILON,    // regularization for PP interaction
+        ALPHA,      // Green’s function splitting parameter
+        EPSILON,    // regularization for PP interaction
 #ifdef ENABLE_AMR
         AMR_MAXLEVEL,       // AMR, maximum refinement level
         AMR_REFX,           // AMR, refinement ratio in x
@@ -655,7 +655,7 @@ std::string FieldSolver::getTagging_m() const {
     std::function<bool(const std::string&)> all_digits = [](const std::string& s) {
         // 15. Feb. 2019
         // https://stackoverflow.com/questions/19678572/how-to-validate-that-there-are-only-digits-in-a-string
-        return std::all_of(s.begin(),  s.end(), 
+        return std::all_of(s.begin(),  s.end(),
         [](char c) { return std::isdigit(c); });
     };
 

--- a/src/Structure/H5PartWrapper.cpp
+++ b/src/Structure/H5PartWrapper.cpp
@@ -168,12 +168,12 @@ void H5PartWrapper::copyFile(const std::string &sourceFile, int lastStep, h5_int
         Ippl::Comm->barrier();
 
         open(flags);
-	props = H5CreateFileProp ();
-	comm = Ippl::getComm();
-	h5err = H5SetPropFileMPIOCollective (props, &comm);
-	assert (h5err != H5_ERR);
-	source = H5OpenFile (sourceFileName.c_str(), H5_O_RDONLY, props);
-	assert (source != (h5_file_t)H5_ERR);
+        props = H5CreateFileProp ();
+        comm = Ippl::getComm();
+        h5err = H5SetPropFileMPIOCollective (props, &comm);
+        assert (h5err != H5_ERR);
+        source = H5OpenFile (sourceFileName.c_str(), H5_O_RDONLY, props);
+        assert (source != (h5_file_t)H5_ERR);
         H5CloseProp (props);
         copyHeader(source);
 

--- a/src/Structure/ParticleMatterInteraction.cpp
+++ b/src/Structure/ParticleMatterInteraction.cpp
@@ -40,7 +40,7 @@ namespace {
         RADIUS, // Radius of the tube
         SIGMA,
         TAU,
-	NPART,
+        NPART,
         SIZE
     };
 }

--- a/src/Structure/SecondaryEmissionPhysics.cpp
+++ b/src/Structure/SecondaryEmissionPhysics.cpp
@@ -81,27 +81,27 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
     if(seNum == 0) {
 
         // The incident particle will be marked for deletion
-	if (!nEmissionMode) {
-	    if( Options::ppdebug ) {
-		/*=========(Velocity with Maxwellian Distribution For Parallel Plate Benchmark)========*/
-		double test_s=1;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;// range for normalized emission speed(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		}
-		double v_emi=test_x*vw;
-		Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
-		// cout<<"Single Eemit[0]: "<<Eemit[0]<<endl;
-		/*---------------------End Of Maxwellian Distribution(For Benchmark)--------------------*/
-	    } else {
+        if (!nEmissionMode) {
+            if( Options::ppdebug ) {
+                /*=========(Velocity with Maxwellian Distribution For Parallel Plate Benchmark)========*/
+                double test_s=1;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;// range for normalized emission speed(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                }
+                double v_emi=test_x*vw;
+                Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
+                // cout<<"Single Eemit[0]: "<<Eemit[0]<<endl;
+                /*---------------------End Of Maxwellian Distribution(For Benchmark)--------------------*/
+            } else {
 
-		// For absorption case in constant simulation particle mode, just use true secondary emission with 1 particle energy distribution for Furman Pivi model.
-		double u2 = IpplRandom();
+                // For absorption case in constant simulation particle mode, just use true secondary emission with 1 particle energy distribution for Furman Pivi model.
+                double u2 = IpplRandom();
 
                 double temp = incEnergy / seEpsn_m[0];
                 double p0 = gammp(sePn_m[0], temp);
@@ -109,9 +109,9 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
                 Eemit[0] = seEpsn_m[0] * invgammp(temp, sePn_m[0]) ;
 
 
-	    }
+            }
 
-	}
+        }
 
 
     } else if(seNum == 1) {
@@ -130,7 +130,7 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
             }
             double v_emi=test_x*vw;
             Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
-          //cout<<"Single Eemit[0]: "<<Eemit[0]<<endl;
+            //cout<<"Single Eemit[0]: "<<Eemit[0]<<endl;
             /*---------------------End Of Maxwellian Distribution(For Benchmark)--------------------*/
         } else {
 
@@ -138,9 +138,9 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
             //double delta_r = calcDeltar(incEnergy, cosTheta);
             double tmp = prob[1] + deltae_m + deltar_m;
             //double ae = delta_e / tmp;
-	    double ae = deltae_m / tmp;
+            double ae = deltae_m / tmp;
             //double ar = delta_r / tmp;
-	    double ar = deltar_m / tmp;
+            double ar = deltar_m / tmp;
             double a_re = ae + ar;
             double urand = IpplRandom();
 
@@ -181,45 +181,45 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
 
         if( Options::ppdebug ) {
             /*==========(Velocity with Maxwellian Distribution For Parallel Plate Benchmark)========*/
-	    if (!nEmissionMode) {
-		/*double Eemit_mean = 0.0;
-		  for(int i = 0; i < seNum; i++) {
-		  Eemit_mean += Eemit[i];
-		  }*/
-		//Eemit[0] = Eemit_mean/seNum;
-		double test_s=1.0;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		}
-		double v_emi=test_x*vw;
-		Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
+            if (!nEmissionMode) {
+                /*double Eemit_mean = 0.0;
+                  for(int i = 0; i < seNum; i++) {
+                  Eemit_mean += Eemit[i];
+                  }*/
+                //Eemit[0] = Eemit_mean/seNum;
+                double test_s=1.0;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                }
+                double v_emi=test_x*vw;
+                Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
 
 
-	    } else {
-		for(int i = 0; i < seNum; i++) {
-		    double test_s=1.0;
-		    double f_x=0;
-		    double test_x=0;
-		    while (test_s>f_x) {
-			test_s=IpplRandom();
-			test_s*=f_max;
-			test_x=IpplRandom();
-			test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
-			f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		    }
-		    double v_emi=test_x*vw;
-		    Eemit[i]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
+            } else {
+                for(int i = 0; i < seNum; i++) {
+                    double test_s=1.0;
+                    double f_x=0;
+                    double test_x=0;
+                    while (test_s>f_x) {
+                        test_s=IpplRandom();
+                        test_s*=f_max;
+                        test_x=IpplRandom();
+                        test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
+                        f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                    }
+                    double v_emi=test_x*vw;
+                    Eemit[i]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
 
-		}
+                }
 
 
-	    }
+            }
             /*---------------------End Of Maxwellian Distribution(For Benchmark)--------------------*/
         } else {
             /*=======================3D velocity for Furman-Pivi's Model====================*/
@@ -234,53 +234,53 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
             double y2_n[seNum];
             double multisin = 1.0;
 
-	    if (!nEmissionMode) {// only emit 1 particle
+            if (!nEmissionMode) {// only emit 1 particle
 
                 double Eemisum = 0.0;
-		for(int i = 0; i < seNum - 1; i++) {
-		    double mu = sePn_m[seNum-1] * (seNum  - i);
-		    double nu =  sePn_m[seNum-1];
-		    double rand_n = IpplRandom();
-		    sin2theta_n[i] = invbetai(rand_n, mu, nu);
-		    cos2theta_n[i] = 1.0 - sin2theta_n[i];
-		    if(i != 0) {
+                for(int i = 0; i < seNum - 1; i++) {
+                    double mu = sePn_m[seNum-1] * (seNum  - i);
+                    double nu =  sePn_m[seNum-1];
+                    double rand_n = IpplRandom();
+                    sin2theta_n[i] = invbetai(rand_n, mu, nu);
+                    cos2theta_n[i] = 1.0 - sin2theta_n[i];
+                    if(i != 0) {
 
-			multisin *=  sin2theta_n[i-1];
-		    }
-		    y2_n[i] = y2 *  multisin * cos2theta_n[i];
-		    Eemit[i] = seEpsn_m[seNum-1] * y2_n[i];
-		    Eemisum += Eemit[i];
-
-
-		}
-
-		Eemit[seNum-1] = Eemit[seNum-2] / cos2theta_n[seNum-2] * sin2theta_n[seNum-2];
-		Eemisum += Eemit[seNum-1];
-
-		Eemit[0] = Eemisum/seNum;
-
-	    } else {// emit seNum particles
-		for(int i = 0; i < seNum - 1; i++) {
-		    double mu = sePn_m[seNum-1] * (seNum  - i);
-		    double nu =  sePn_m[seNum-1];
-		    double rand_n = IpplRandom();
-		    sin2theta_n[i] = invbetai(rand_n, mu, nu);
-		    cos2theta_n[i] = 1.0 - sin2theta_n[i];
-		    if(i != 0) {
-
-			multisin *=  sin2theta_n[i-1];
-		    }
-		    y2_n[i] = y2 *  multisin * cos2theta_n[i];
-		    Eemit[i] = seEpsn_m[seNum-1] * y2_n[i];
+                        multisin *=  sin2theta_n[i-1];
+                    }
+                    y2_n[i] = y2 *  multisin * cos2theta_n[i];
+                    Eemit[i] = seEpsn_m[seNum-1] * y2_n[i];
+                    Eemisum += Eemit[i];
 
 
-		}
+                }
 
-		Eemit[seNum-1] = Eemit[seNum-2] / cos2theta_n[seNum-2] * sin2theta_n[seNum-2];
+                Eemit[seNum-1] = Eemit[seNum-2] / cos2theta_n[seNum-2] * sin2theta_n[seNum-2];
+                Eemisum += Eemit[seNum-1];
 
-        /*=====================================================================================================*/
-	    }
-	}
+                Eemit[0] = Eemisum/seNum;
+
+            } else {// emit seNum particles
+                for(int i = 0; i < seNum - 1; i++) {
+                    double mu = sePn_m[seNum-1] * (seNum  - i);
+                    double nu =  sePn_m[seNum-1];
+                    double rand_n = IpplRandom();
+                    sin2theta_n[i] = invbetai(rand_n, mu, nu);
+                    cos2theta_n[i] = 1.0 - sin2theta_n[i];
+                    if(i != 0) {
+
+                        multisin *=  sin2theta_n[i-1];
+                    }
+                    y2_n[i] = y2 *  multisin * cos2theta_n[i];
+                    Eemit[i] = seEpsn_m[seNum-1] * y2_n[i];
+
+
+                }
+
+                Eemit[seNum-1] = Eemit[seNum-2] / cos2theta_n[seNum-2] * sin2theta_n[seNum-2];
+
+                /*=====================================================================================================*/
+            }
+        }
 
     }
 
@@ -292,81 +292,81 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
 
     size_t lowMark = itsBunch->getLocalNum();
     if (!nEmissionMode) {// emit only 1 particle with larger charge instead of emit seNum secondaries.
-	//if (seNum>0) {// we dont delete particles even when seNum==0.
-	double gamma_const = Eemit[0] / Physics::m_e/1.0e9 + 1.0;
-	double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
-	double P_emitted = gamma_const * beta_const;
+        //if (seNum>0) {// we dont delete particles even when seNum==0.
+        double gamma_const = Eemit[0] / Physics::m_e/1.0e9 + 1.0;
+        double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
+        double P_emitted = gamma_const * beta_const;
 
-	Vector_t P_local;
-	Vector_t P_global = (0.0);
+        Vector_t P_local;
+        Vector_t P_global = (0.0);
 
-	if( Options::ppdebug ) {
+        if( Options::ppdebug ) {
 
-	    P_global = P_emitted*TriNorm_l;// 1D for parallel plate benchmark
+            P_global = P_emitted*TriNorm_l;// 1D for parallel plate benchmark
 
-	} else {
-	    /*==================3D for Furman-Pivi's Model====================*/
-	    P_local[2] = P_emitted * cos(emiTheta[0]);
-	    P_local[1] = P_emitted * sin(emiTheta[0]) * sin(emiPhi[0]);
-	    P_local[0] = P_emitted * sin(emiTheta[0]) * cos(emiPhi[0]);
-	    P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//Pivi's model
-	    /*================================================================*/
+        } else {
+            /*==================3D for Furman-Pivi's Model====================*/
+            P_local[2] = P_emitted * cos(emiTheta[0]);
+            P_local[1] = P_emitted * sin(emiTheta[0]) * sin(emiPhi[0]);
+            P_local[0] = P_emitted * sin(emiTheta[0]) * cos(emiPhi[0]);
+            P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//Pivi's model
+            /*================================================================*/
 
 
-	}
-	itsBunch->create(1);
-	itsBunch->R[lowMark] = interCoords_l;
+        }
+        itsBunch->create(1);
+        itsBunch->R[lowMark] = interCoords_l;
 
-	itsBunch->P[lowMark] = P_global;
-	itsBunch->Bin[lowMark] = 0;
-	itsBunch->PType[lowMark] = ParticleType::NEWSECONDARY;
-	itsBunch->TriID[lowMark] = 0;
-	//itsBunch->Q[lowMark] = incQ_l*seNum;// charge of simulation particle will be sum of secondaies
-	itsBunch->Q[lowMark] = incQ_l*seyNum;// charge of simulation particle will be multiplied by SEY.
-	itsBunch->Ef[lowMark] = Vector_t(0.0);
-	itsBunch->Bf[lowMark] = Vector_t(0.0);
-	itsBunch->dt[lowMark] = itsBunch->getdT();
-	    //}
+        itsBunch->P[lowMark] = P_global;
+        itsBunch->Bin[lowMark] = 0;
+        itsBunch->PType[lowMark] = ParticleType::NEWSECONDARY;
+        itsBunch->TriID[lowMark] = 0;
+        //itsBunch->Q[lowMark] = incQ_l*seNum;// charge of simulation particle will be sum of secondaies
+        itsBunch->Q[lowMark] = incQ_l*seyNum;// charge of simulation particle will be multiplied by SEY.
+        itsBunch->Ef[lowMark] = Vector_t(0.0);
+        itsBunch->Bf[lowMark] = Vector_t(0.0);
+        itsBunch->dt[lowMark] = itsBunch->getdT();
+        //}
 
 
 
     } else {
-	for(size_t i = 0; i < (size_t) seNum; i++) {
+        for(size_t i = 0; i < (size_t) seNum; i++) {
 
-	    double gamma_const = Eemit[i] / Physics::m_e/1.0e9 + 1.0;
-	    double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
-	    double P_emitted = gamma_const * beta_const;
+            double gamma_const = Eemit[i] / Physics::m_e/1.0e9 + 1.0;
+            double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
+            double P_emitted = gamma_const * beta_const;
 
-	    Vector_t P_local;
-	    Vector_t P_global = (0.0);
+            Vector_t P_local;
+            Vector_t P_global = (0.0);
 
-	    if( Options::ppdebug ) {
+            if( Options::ppdebug ) {
 
-		P_global = P_emitted*TriNorm_l;// 1D for parallel plate benchmark
+                P_global = P_emitted*TriNorm_l;// 1D for parallel plate benchmark
 
-	    } else {
-		/*==================3D for Furman-Pivi's Model====================*/
-		P_local[2] = P_emitted * cos(emiTheta[i]);
-		P_local[1] = P_emitted * sin(emiTheta[i]) * sin(emiPhi[i]);
-		P_local[0] = P_emitted * sin(emiTheta[i]) * cos(emiPhi[i]);
-		P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//Pivi's model
-		/*================================================================*/
+            } else {
+                /*==================3D for Furman-Pivi's Model====================*/
+                P_local[2] = P_emitted * cos(emiTheta[i]);
+                P_local[1] = P_emitted * sin(emiTheta[i]) * sin(emiPhi[i]);
+                P_local[0] = P_emitted * sin(emiTheta[i]) * cos(emiPhi[i]);
+                P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//Pivi's model
+                /*================================================================*/
 
 
-	    }
-	    itsBunch->create(1);
-	    itsBunch->R[lowMark+i] = interCoords_l;
+            }
+            itsBunch->create(1);
+            itsBunch->R[lowMark+i] = interCoords_l;
 
-	    itsBunch->P[lowMark+i] = P_global;
-	    itsBunch->Bin[lowMark+i] = 0;
-	    itsBunch->PType[lowMark+i] = ParticleType::NEWSECONDARY;
-	    itsBunch->TriID[lowMark+i] = 0;
-	    itsBunch->Q[lowMark+i] = incQ_l;
-	    itsBunch->Ef[lowMark+i] = Vector_t(0.0);
-	    itsBunch->Bf[lowMark+i] = Vector_t(0.0);
-	    itsBunch->dt[lowMark+i] = itsBunch->getdT();
+            itsBunch->P[lowMark+i] = P_global;
+            itsBunch->Bin[lowMark+i] = 0;
+            itsBunch->PType[lowMark+i] = ParticleType::NEWSECONDARY;
+            itsBunch->TriID[lowMark+i] = 0;
+            itsBunch->Q[lowMark+i] = incQ_l;
+            itsBunch->Ef[lowMark+i] = Vector_t(0.0);
+            itsBunch->Bf[lowMark+i] = Vector_t(0.0);
+            itsBunch->dt[lowMark+i] = itsBunch->getdT();
 
-	}
+        }
     }
 
     IpplTimings::stopTimer(TPnSec_m);
@@ -409,14 +409,14 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
     double test_a;//benchmark
     double test_asq;//benchmark
     if( Options::ppdebug ) {
-	f_max=vw/vt*exp(-0.5);// velocity a Maxwellian distribution. See Anza et al.,Phys. Plasmas 17, 062110 (2010)
+        f_max=vw/vt*exp(-0.5);// velocity a Maxwellian distribution. See Anza et al.,Phys. Plasmas 17, 062110 (2010)
 
-	test_a=vt/vw;
-	test_asq=test_a*test_a;
+        test_a=vt/vw;
+        test_asq=test_a*test_a;
     } else {// Energy Maxwell-Boltzmann distribution f(E)=E/a^2*exp(-E/a), a= kinetic energy w.r.t thermal speed vt. See www.nuc.berkeley.edu/dept/Courses/NE-255/minicourse.pdf p.20
-	test_a = Physics::m_e*(1.0/sqrt(1-vt*vt/Physics::c/Physics::c)-1.0)*1.0e9;// m_e GeV change it to eV
-	test_asq=test_a*test_a;
-	f_max= 1.0/test_a*exp(-1.0);
+        test_a = Physics::m_e*(1.0/sqrt(1-vt*vt/Physics::c/Physics::c)-1.0)*1.0e9;// m_e GeV change it to eV
+        test_asq=test_a*test_a;
+        f_max= 1.0/test_a*exp(-1.0);
 
     }
 
@@ -425,139 +425,139 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
         // 1D emission angle along the surface triangle normal
 
     } else {
-	if (!nEmissionMode) {
+        if (!nEmissionMode) {
 
-	    double tmp1 = IpplRandom();
-	    double tmp2 = IpplRandom();
-	    double seAlpha = 1.0;
-	    double temp = 1.0 / (1.0 + seAlpha);// pow(cosine(theta),seAlpha) distribution. Here seAlpha=1.0
-	    emiTheta[0] = acos(pow(tmp1, temp));
-	    emiPhi[0] = Physics::two_pi * tmp2;
+            double tmp1 = IpplRandom();
+            double tmp2 = IpplRandom();
+            double seAlpha = 1.0;
+            double temp = 1.0 / (1.0 + seAlpha);// pow(cosine(theta),seAlpha) distribution. Here seAlpha=1.0
+            emiTheta[0] = acos(pow(tmp1, temp));
+            emiPhi[0] = Physics::two_pi * tmp2;
 
 
-	} else {
+        } else {
 
-	    for(int i = 0; i < seNum; i++) {
+            for(int i = 0; i < seNum; i++) {
 
-		double tmp1 = IpplRandom();
-		double tmp2 = IpplRandom();
-		double seAlpha = 1.0;
-		double temp = 1.0 / (1.0 + seAlpha);// pow(cosine(theta),seAlpha) distribution. Here seAlpha=1.0
-		emiTheta[i] = acos(pow(tmp1, temp));
-		emiPhi[i] = Physics::two_pi * tmp2;
+                double tmp1 = IpplRandom();
+                double tmp2 = IpplRandom();
+                double seAlpha = 1.0;
+                double temp = 1.0 / (1.0 + seAlpha);// pow(cosine(theta),seAlpha) distribution. Here seAlpha=1.0
+                emiTheta[i] = acos(pow(tmp1, temp));
+                emiPhi[i] = Physics::two_pi * tmp2;
 
-	    }
+            }
 
-	}
+        }
     }
 
     if(seNum == 0) {
-	if (!nEmissionMode) {
-	    if( Options::ppdebug ) {
-		double test_s=1.0;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;// truncation range for emission speed(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		}
-		double v_emi=test_x*vw;
-		Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/Physics::c/Physics::c)-1)*Physics::m_e*1.0e9;
+        if (!nEmissionMode) {
+            if( Options::ppdebug ) {
+                double test_s=1.0;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;// truncation range for emission speed(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                }
+                double v_emi=test_x*vw;
+                Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/Physics::c/Physics::c)-1)*Physics::m_e*1.0e9;
             } else {
-		double test_s=1.0;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {// rejection & acceptance method
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
-		}
+                double test_s=1.0;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {// rejection & acceptance method
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
+                }
 
-		Eemit[0]=test_x;
+                Eemit[0]=test_x;
 
 
-	    }
+            }
 
-	}
+        }
         // else The incident particle will be marked for deletion
 
 
     } else {
         seType = 2;
         if (!nEmissionMode) {
-	    if( Options::ppdebug ) {
-		double test_s=1.0;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;// truncation range for emission speed(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		}
-		double v_emi=test_x*vw;
-		Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/Physics::c/Physics::c)-1)*Physics::m_e*1.0e9;
+            if( Options::ppdebug ) {
+                double test_s=1.0;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;// truncation range for emission speed(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                }
+                double v_emi=test_x*vw;
+                Eemit[0]=(1.0/sqrt(1.0-v_emi*v_emi/Physics::c/Physics::c)-1)*Physics::m_e*1.0e9;
             } else {
-		double test_s=1.0;
-		double f_x=0;
-		double test_x=0;
-		while (test_s>f_x) {
-		    test_s=IpplRandom();
-		    test_s*=f_max;
-		    test_x=IpplRandom();
-		    test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
-		    f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
-		}
+                double test_s=1.0;
+                double f_x=0;
+                double test_x=0;
+                while (test_s>f_x) {
+                    test_s=IpplRandom();
+                    test_s*=f_max;
+                    test_x=IpplRandom();
+                    test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
+                    f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
+                }
 
-		Eemit[0]=test_x;
+                Eemit[0]=test_x;
 
-	    }
+            }
 
-	} else {
-	    if( Options::ppdebug ) {
-		/*=======================Maxwellian Distribution====================*/
-		// the velocity distribution for Vaughan's model:fu=u*vw*vw/vt/vt*exp(-u*u*vw*vw/vt/vt) valid for benchmarking;
+        } else {
+            if( Options::ppdebug ) {
+                /*=======================Maxwellian Distribution====================*/
+                // the velocity distribution for Vaughan's model:fu=u*vw*vw/vt/vt*exp(-u*u*vw*vw/vt/vt) valid for benchmarking;
 
-		for(int i = 0; i < seNum; i++) {
-		    double test_s=1.0;
-		    double f_x=0;
-		    double test_x=0;
-		    while (test_s>f_x) {
-			test_s=IpplRandom();
-			test_s*=f_max;
-			test_x=IpplRandom();
-			test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
-			f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
-		    }
-		    double v_emi=test_x*vw;
-		    Eemit[i]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
+                for(int i = 0; i < seNum; i++) {
+                    double test_s=1.0;
+                    double f_x=0;
+                    double test_x=0;
+                    while (test_s>f_x) {
+                        test_s=IpplRandom();
+                        test_s*=f_max;
+                        test_x=IpplRandom();
+                        test_x*=10*test_a;//range for normalized emission speed(0,10*test_a);
+                        f_x=test_x/test_asq*exp(-test_x*test_x/2/test_asq);
+                    }
+                    double v_emi=test_x*vw;
+                    Eemit[i]=(1.0/sqrt(1.0-v_emi*v_emi/9.0/1e16)-1)*Physics::m_e*1.0e9;
 
-		}
+                }
 
-		/*---------------------End Of Maxwellian Distribution--------------------*/
-	    } else {// energy thermal distribution for Vaughan model
-		for(int i = 0; i < seNum; i++) {
-		    double test_s=1.0;
-		    double f_x=0;
-		    double test_x=0;
-		    while (test_s>f_x) {
-			test_s=IpplRandom();
-			test_s*=f_max;
-			test_x=IpplRandom();
-			test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
-			f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
-		    }
+                /*---------------------End Of Maxwellian Distribution--------------------*/
+            } else {// energy thermal distribution for Vaughan model
+                for(int i = 0; i < seNum; i++) {
+                    double test_s=1.0;
+                    double f_x=0;
+                    double test_x=0;
+                    while (test_s>f_x) {
+                        test_s=IpplRandom();
+                        test_s*=f_max;
+                        test_x=IpplRandom();
+                        test_x*=10*test_a;// truncation range for emission energy(0,10*test_a);
+                        f_x=test_x/test_asq*exp(-test_x/test_a);// thermal distribution for energy
+                    }
 
-		    Eemit[i]=test_x;
-		}
-	    }
-	}
+                    Eemit[i]=test_x;
+                }
+            }
+        }
     }
 
     Vector_t z_unit = TriNorm;
@@ -568,74 +568,74 @@ void SecondaryEmissionPhysics::nSec(const double &incEnergy,
 
     size_t lowMark = itsBunch->getLocalNum();
     if (!nEmissionMode) {
-	double gamma_const = Eemit[0] / Physics::m_e/1.0e9 + 1.0;
-	double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
-	double P_emitted = gamma_const * beta_const;
+        double gamma_const = Eemit[0] / Physics::m_e/1.0e9 + 1.0;
+        double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
+        double P_emitted = gamma_const * beta_const;
 
 
-	Vector_t P_local;
-	Vector_t P_global = (0.0);
-	if( Options::ppdebug ) {
+        Vector_t P_local;
+        Vector_t P_global = (0.0);
+        if( Options::ppdebug ) {
 
-	    P_global = P_emitted*TriNorm_l;//1D for parallel plate benchmark
+            P_global = P_emitted*TriNorm_l;//1D for parallel plate benchmark
 
-	} else {
-	    /*==================3D Vaughan' Model==========================================*/
-	    P_local[2] = P_emitted * cos(emiTheta[0]);
-	    P_local[1] = P_emitted * sin(emiTheta[0]) * sin(emiPhi[0]);
-	    P_local[0] = P_emitted * sin(emiTheta[0]) * cos(emiPhi[0]);
-	    P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;// the same cosine distribution as Pivi's model
-	    /*=============================================================================*/
-	}
+        } else {
+            /*==================3D Vaughan' Model==========================================*/
+            P_local[2] = P_emitted * cos(emiTheta[0]);
+            P_local[1] = P_emitted * sin(emiTheta[0]) * sin(emiPhi[0]);
+            P_local[0] = P_emitted * sin(emiTheta[0]) * cos(emiPhi[0]);
+            P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;// the same cosine distribution as Pivi's model
+            /*=============================================================================*/
+        }
 
-	itsBunch->create(1);
-	itsBunch->R[lowMark] = interCoords_l;
-	itsBunch->P[lowMark] = P_global;
-	itsBunch->Bin[lowMark] = 0;
-	itsBunch->PType[lowMark] = ParticleType::NEWSECONDARY;
-	itsBunch->TriID[lowMark] = 0;
-	itsBunch->Q[lowMark] = incQ_l*seyNum;
-	itsBunch->Ef[lowMark] = Vector_t(0.0);
-	itsBunch->Bf[lowMark] = Vector_t(0.0);
-	itsBunch->dt[lowMark] = itsBunch->getdT();
+        itsBunch->create(1);
+        itsBunch->R[lowMark] = interCoords_l;
+        itsBunch->P[lowMark] = P_global;
+        itsBunch->Bin[lowMark] = 0;
+        itsBunch->PType[lowMark] = ParticleType::NEWSECONDARY;
+        itsBunch->TriID[lowMark] = 0;
+        itsBunch->Q[lowMark] = incQ_l*seyNum;
+        itsBunch->Ef[lowMark] = Vector_t(0.0);
+        itsBunch->Bf[lowMark] = Vector_t(0.0);
+        itsBunch->dt[lowMark] = itsBunch->getdT();
 
     } else {
-	for(size_t i = 0; i < (size_t) seNum; i++) {
+        for(size_t i = 0; i < (size_t) seNum; i++) {
 
-	    double gamma_const = Eemit[i] / Physics::m_e/1.0e9 + 1.0;
-	    double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
-	    double P_emitted = gamma_const * beta_const;
-
-
-	    Vector_t P_local;
-	    Vector_t P_global = (0.0);
-	    if( Options::ppdebug ) {
-
-		P_global = P_emitted*TriNorm_l;//1D for parallel plate benchmark
-
-	    } else {
-		/*==================3D Vaughan' Model==========================================*/
-		P_local[2] = P_emitted * cos(emiTheta[i]);
-		P_local[1] = P_emitted * sin(emiTheta[i]) * sin(emiPhi[i]);
-		P_local[0] = P_emitted * sin(emiTheta[i]) * cos(emiPhi[i]);
-		P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//the same cosine distribution as Pivi's model
-		/*=============================================================================*/
-	    }
-
-	    itsBunch->create(1);
-	    itsBunch->R[lowMark+i] = interCoords_l;
-
-	    itsBunch->P[lowMark+i] = P_global;
-	    itsBunch->Bin[lowMark+i] = 0;
-	    itsBunch->PType[lowMark+i] = ParticleType::NEWSECONDARY;
-	    itsBunch->TriID[lowMark+i] = 0;
-	    itsBunch->Q[lowMark+i] = incQ_l;
-	    itsBunch->Ef[lowMark+i] = Vector_t(0.0);
-	    itsBunch->Bf[lowMark+i] = Vector_t(0.0);
-	    itsBunch->dt[lowMark+i] = itsBunch->getdT();
+            double gamma_const = Eemit[i] / Physics::m_e/1.0e9 + 1.0;
+            double beta_const = sqrt(1.0 - 1.0 / pow(gamma_const, 2.0));
+            double P_emitted = gamma_const * beta_const;
 
 
-	}
+            Vector_t P_local;
+            Vector_t P_global = (0.0);
+            if( Options::ppdebug ) {
+
+                P_global = P_emitted*TriNorm_l;//1D for parallel plate benchmark
+
+            } else {
+                /*==================3D Vaughan' Model==========================================*/
+                P_local[2] = P_emitted * cos(emiTheta[i]);
+                P_local[1] = P_emitted * sin(emiTheta[i]) * sin(emiPhi[i]);
+                P_local[0] = P_emitted * sin(emiTheta[i]) * cos(emiPhi[i]);
+                P_global = P_local[0]*x_unit + P_local[1]*y_unit +  P_local[2]*z_unit;//the same cosine distribution as Pivi's model
+                /*=============================================================================*/
+            }
+
+            itsBunch->create(1);
+            itsBunch->R[lowMark+i] = interCoords_l;
+
+            itsBunch->P[lowMark+i] = P_global;
+            itsBunch->Bin[lowMark+i] = 0;
+            itsBunch->PType[lowMark+i] = ParticleType::NEWSECONDARY;
+            itsBunch->TriID[lowMark+i] = 0;
+            itsBunch->Q[lowMark+i] = incQ_l;
+            itsBunch->Ef[lowMark+i] = Vector_t(0.0);
+            itsBunch->Bf[lowMark+i] = Vector_t(0.0);
+            itsBunch->dt[lowMark+i] = itsBunch->getdT();
+
+
+        }
     }
 
     IpplTimings::stopTimer(TPnSec_m);

--- a/src/ValueDefinitions/RealConstant.cpp
+++ b/src/ValueDefinitions/RealConstant.cpp
@@ -60,8 +60,8 @@ RealConstant::RealConstant():
     opal->create(new RealConstant("CLIGHT", this, Physics::c));
 
     opal->create(new RealConstant("OPALVERSION", this, OPAL_VERSION_MAJOR * 10000
-				  + OPAL_VERSION_MINOR * 100
-				  + OPAL_VERSION_PATCH));
+                                  + OPAL_VERSION_MINOR * 100
+                                  + OPAL_VERSION_PATCH));
     opal->create(new RealConstant("RANK", this, Ippl::myNode()));
 }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [replace all tabs with 4 spaces](https://gitlab.psi.ch/OPAL/src/merge_requests/88) |
> | **GitLab MR Number** | [88](https://gitlab.psi.ch/OPAL/src/merge_requests/88) |
> | **Date Originally Opened** | Thu, 2 May 2019 |
> | **Date Originally Merged** | Fri, 3 May 2019 |
> | **Approved on GitLab by** | @https://intranet.psi.ch/main/jochemsnuverink |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Minor annoyance when reading source code. Replacing all tabs with four spaces as demanded by the [coding style guide lines](https://gitlab.psi.ch/OPAL/src/wikis/For%20Developers/Codingstyle#51-indentation).