### PR TITLE
memprof_m does not exist for non linux systems

### DIFF
--- a/src/Structure/DataSink.cpp
+++ b/src/Structure/DataSink.cpp
@@ -35,11 +35,9 @@ DataSink::DataSink() :
     H5call_m(0),
     lossWrCounter_m(0),
     doHDF5_m(true),
-    h5wrapper_m(NULL),
+    h5wrapper_m(NULL)
 #ifdef __linux__
-    memprof_m(new MemoryProfiler())
-#else
-    memprof_m(nullptr)
+    , memprof_m(new MemoryProfiler())
 #endif
 { }
 
@@ -48,11 +46,9 @@ DataSink::DataSink(H5PartWrapper *h5wrapper, int restartStep):
     nMaxBunches_m(1),
     H5call_m(0),
     lossWrCounter_m(0),
-    h5wrapper_m(h5wrapper),
+    h5wrapper_m(h5wrapper)
 #ifdef __linux__
-    memprof_m(new MemoryProfiler())
-#else
-    memprof_m(nullptr)
+    , memprof_m(new MemoryProfiler())
 #endif
 {
     namespace fs = boost::filesystem;
@@ -138,11 +134,9 @@ DataSink::DataSink(H5PartWrapper *h5wrapper):
     nMaxBunches_m(1),
     H5call_m(0),
     lossWrCounter_m(0),
-    h5wrapper_m(h5wrapper),
+    h5wrapper_m(h5wrapper)
 #ifdef __linux__
-    memprof_m(new MemoryProfiler())
-#else
-    memprof_m(nullptr)
+    , memprof_m(new MemoryProfiler())
 #endif
 {
     /// Constructor steps:


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @https://intranet.psi.ch/main/jochemsnuverink |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [memprof_m does not exist for non linux s...](https://gitlab.psi.ch/OPAL/src/merge_requests/93) |
> | **GitLab MR Number** | [93](https://gitlab.psi.ch/OPAL/src/merge_requests/93) |
> | **Date Originally Opened** | Fri, 10 May 2019 |
> | **Date Originally Merged** | Fri, 10 May 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

on non-linux systems the `DataSink::memprof_m` does not exist https://gitlab.psi.ch/OPAL/src/blob/master/src/Structure/DataSink.h#L317
and should be removed from the source as well.

```c
#ifdef __linux__
    std::unique_ptr<MemoryProfiler> memprof_m;
#endif
```