### PR TITLE
fixing dataDir in case where sampler is used

### DIFF
--- a/src/Optimize/OpalSimulation.cpp
+++ b/src/Optimize/OpalSimulation.cpp
@@ -202,13 +202,13 @@ void OpalSimulation::setupSimulation() {
 
     CmdArguments_t args = getArgs();
     std::string restartfile = args->getArg<std::string>("restartfile", "", false);
-    std::string dataDir = simulationDirName_ + "/data";
 
     if ( id_m > -1 ) {
         std::ostringstream tmp;
         tmp << simTmpDir_ << "/" << id_m;
         simulationDirName_ = tmp.str();
     }
+    std::string dataDir = simulationDirName_ + "/data";
 
     OpalData *opal = OpalData::getInstance();
     opal->setOptimizerFlag();


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [fixing dataDir in case where sampler is ...](https://gitlab.psi.ch/OPAL/src/merge_requests/116) |
> | **GitLab MR Number** | [116](https://gitlab.psi.ch/OPAL/src/merge_requests/116) |
> | **Date Originally Opened** | Tue, 25 Jun 2019 |
> | **Date Originally Merged** | Wed, 26 Jun 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Commit e5eabf06 introduced a bug that prevents users from using the sampler.