### PR TITLE
Resolve "bugfix: iterators must be incremented at end of for-loop in Cyclotron::apply()"

### DIFF
--- a/src/Classic/AbsBeamline/Cyclotron.cpp
+++ b/src/Classic/AbsBeamline/Cyclotron.cpp
@@ -473,10 +473,6 @@ bool Cyclotron::apply(const Vector_t &R, const Vector_t &P, const double &t, Vec
         int fcount = 0;
 
         for(; fi != RFfields_m.end(); ++fi, ++rffi, ++rfphii, ++escali, ++superposei) {
-            if(myBFieldType_m == SYNCHRO) {
-                ++rffci, ++rfvci;
-            }
-
             (*fi)->getFieldDimensions(xBegin, xEnd, yBegin, yEnd, zBegin, zEnd);
 	    bool SuperPose = *superposei;
             if (fcount > 0 && !SuperPose) {
@@ -549,6 +545,8 @@ bool Cyclotron::apply(const Vector_t &R, const Vector_t &P, const double &t, Vec
                 *gmsg << "RF Frequency = " << frequency << " MHz" << endl;
                 waiting_for_gap = 0;
             }
+            ++rffci; // myBFieldType is SYNCHRO! See above continue statement if not.
+            ++rfvci;
         }
     }
     return false;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "bugfix: iterators must be incre...](https://gitlab.psi.ch/OPAL/src/merge_requests/133) |
> | **GitLab MR Number** | [133](https://gitlab.psi.ch/OPAL/src/merge_requests/133) |
> | **Date Originally Opened** | Mon, 8 Jul 2019 |
> | **Date Originally Merged** | Tue, 9 Jul 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #331

Issue #326 fixes the same bug in master.