### PR TITLE
remove old and now incorrect comment

### DIFF
--- a/src/Classic/Solvers/CollimatorPhysics.cpp
+++ b/src/Classic/Solvers/CollimatorPhysics.cpp
@@ -730,8 +730,6 @@ void CollimatorPhysics::gatherStatistics() {
                                              rediffusedStat_m,
                                              stoppedPartStat_m};
 
-    // allreduce doesn't seem to work with unsigned int therefore
-    // use long which can store unsigned int.
     allreduce(&(partStatistics[0]), numItems, std::plus<unsigned int>());
 
     totalPartsInMat_m = partStatistics[0];


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [remove old and now incorrect comment](https://gitlab.psi.ch/OPAL/src/merge_requests/137) |
> | **GitLab MR Number** | [137](https://gitlab.psi.ch/OPAL/src/merge_requests/137) |
> | **Date Originally Opened** | Wed, 10 Jul 2019 |
> | **Date Originally Merged** | Wed, 10 Jul 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Remove a comment which was introduced into the code with MR !130 and which isn't correct anymore.