### PR TITLE
Merge branch '355-wrong-bunch-information' into 'master'

### DIFF
--- a/src/Classic/Algorithms/PartBunchBase.hpp
+++ b/src/Classic/Algorithms/PartBunchBase.hpp
@@ -2178,9 +2178,11 @@ Inform &PartBunchBase<T, Dim>::print(Inform &os) {
     if(getTotalNum() != 0) {  // to suppress Nan's
         Inform::FmtFlags_t ff = os.flags();
 
-        double pathLength = get_sPos();
+        double pathLength = 0.0;
         if (OpalData::getInstance()->isInOPALCyclMode()) {
             pathLength = getLPath();
+        } else {
+            pathLength = get_sPos();
         }
 
         os << std::scientific;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | frey_m |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '355-wrong-bunch-informatio...](https://gitlab.psi.ch/OPAL/src/merge_requests/173) |
> | **GitLab MR Number** | [173](https://gitlab.psi.ch/OPAL/src/merge_requests/173) |
> | **Date Originally Opened** | Thu, 12 Sep 2019 |
> | **Date Originally Merged** | Mon, 16 Sep 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Wrong bunch information"

See merge request OPAL/src!171

(cherry picked from commit cb89cfdeaa2187a3ce0f0eec8816ea5f9c701f0b)

1dbe8481 remove unit conversion

Closes #355 