### PR TITLE
Resolve "Doxyfile INPUT only containing `OPAL-Map` input files"

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -764,15 +764,10 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-#INPUT                  = ./src \
-#                         ./src/Classic \
-#                        ./ippl/src \
-#			 ./optimizer
+INPUT                  = ./src \
+                         ./ippl/src \
+                         ./optimizer
 
-INPUT                   =   ./src/Algorithms/ThickTracker.h \
-                            ./src/Algorithms/Hamiltonian.h  \
-                            ./src/Algorithms/MapAnalyser.h \
-                                
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv
@@ -796,10 +791,10 @@ FILE_PATTERNS          = *.c \
                          *.cc \
                          *.h \
                          *.hh \
-			 *.H \
-			 *.f90 \
-			 *.hpp
-			 
+                         *.H \
+                         *.f90 \
+                         *.hpp
+
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @https://intranet.psi.ch/main/jochemsnuverink |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Doxyfile INPUT only containing ...](https://gitlab.psi.ch/OPAL/src/merge_requests/189) |
> | **GitLab MR Number** | [189](https://gitlab.psi.ch/OPAL/src/merge_requests/189) |
> | **Date Originally Opened** | Fri, 18 Oct 2019 |
> | **Date Originally Merged** | Fri, 18 Oct 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #373