### PR TITLE
Resolve "replace deprecated std::bind2nd() in CLASSIC"

### DIFF
--- a/src/Classic/Algebra/Vector.h
+++ b/src/Classic/Algebra/Vector.h
@@ -25,10 +25,7 @@
 #include <algorithm>
 #include <numeric>
 #include <cmath>
-
-#ifndef POOMA_GPLUSPLUS
 #include <functional>
-#endif
 
 // Template class Vector<T>
 // ------------------------------------------------------------------------
@@ -161,7 +158,7 @@ Vector<T> Vector<T>::operator-() const {
 template<class T>
 Vector<T> &Vector<T>::operator*=(const T &val) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::multiplies<T>(), val));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, val));
     return *this;
 }
 
@@ -169,7 +166,7 @@ Vector<T> &Vector<T>::operator*=(const T &val) {
 template<class T>
 Vector<T> &Vector<T>::operator/=(const T &val) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::divides<T>(), val));
+                   std::bind(std::divides<T>(), std::placeholders::_1, val));
     return *this;
 }
 
@@ -238,7 +235,7 @@ template<class T>
 Vector<T> operator*(const T &x, const Vector<T> &V1) {
     Vector<T> result = V1;
     std::transform(V1.begin(), V1.end(), result.begin(),
-                   std::bind2nd(std::multiplies<T>(), x));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, x));
     return result;
 }
 

--- a/src/Classic/FixedAlgebra/FLieGenerator.hpp
+++ b/src/Classic/FixedAlgebra/FLieGenerator.hpp
@@ -27,8 +27,7 @@
 #include "FixedAlgebra/FTps.h"
 #include <complex>
 #include <iosfwd>
-
-
+#include <functional>
 
 // Template class FLieGenerator<T,N>.
 // This code contains various tweaks for speed.
@@ -149,14 +148,13 @@ FLieGenerator<T, N> FLieGenerator<T, N>::operator-() const {
     }
 }
 
-
 template<class T, int N>
 FLieGenerator<T, N> &FLieGenerator<T, N>::operator*=(const T &val) {
     if(itsOrder < 0) {
         return *this;
     } else {
         std::transform(itsCoeffs.begin(), itsCoeffs.end(), itsCoeffs.begin(),
-                       std::bind2nd(std::multiplies<T>(), val));
+                       std::bind(std::multiplies<T>(), std::placeholders::_1, val));
         return *this;
     }
 }
@@ -168,7 +166,7 @@ FLieGenerator<T, N> &FLieGenerator<T, N>::operator/=(const T &val) {
         return *this;
     } else {
         std::transform(itsCoeffs.begin(), itsCoeffs.end(), itsCoeffs.begin(),
-                       std::bind2nd(std::divides<T>(), val));
+                       std::bind(std::divides<T>(), std::placeholders::_1, val));
         return *this;
     }
 }

--- a/src/Classic/FixedAlgebra/FMatrix.h
+++ b/src/Classic/FixedAlgebra/FMatrix.h
@@ -25,7 +25,7 @@
 #include "Utilities/SizeError.h"
 #include <algorithm>
 #include <numeric>
-
+#include <functional>
 
 // Template class FMatrix<T,R,C>
 // ------------------------------------------------------------------------
@@ -174,7 +174,7 @@ FMatrix<T, R, C> &FMatrix<T, R, C>::operator=(const FArray2D<T, R, C> &rhs) {
 template<class T, int R, int C>
 FMatrix<T, R, C> &FMatrix<T, R, C>::operator*=(const T &rhs) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::multiplies<T>(), rhs));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, rhs));
     return *this;
 }
 
@@ -182,7 +182,7 @@ FMatrix<T, R, C> &FMatrix<T, R, C>::operator*=(const T &rhs) {
 template<class T, int R, int C>
 FMatrix<T, R, C> &FMatrix<T, R, C>::operator/=(const T &rhs) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::divides<T>(), rhs));
+                   std::bind(std::divides<T>(), std::placeholders::_1, rhs));
     return *this;
 }
 

--- a/src/Classic/FixedAlgebra/FTps.hpp
+++ b/src/Classic/FixedAlgebra/FTps.hpp
@@ -575,17 +575,15 @@ template <class T, int N>
 FTps<T, N> &FTps<T, N>::operator*=(const T &rhs) {
     unique();
     std::transform(begin(getMinOrder()), end(getMaxOrder()), begin(getMinOrder()),
-                   std::bind2nd(std::multiplies<T>(), rhs));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, rhs));
     return *this;
 }
-
 
 template <class T, int N>
 FTps<T, N> &FTps<T, N>::operator/=(const T &rhs) {
     if(rhs == T(0)) throw DivideError("FTps::operator/=()");
     return *this *= T(1) / rhs;
 }
-
 
 template <class T, int N>
 FTps<T, N> FTps<T, N>::scaleMonomials(const FTps<T, N> &rhs) const {

--- a/src/Classic/FixedAlgebra/FVector.h
+++ b/src/Classic/FixedAlgebra/FVector.h
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <numeric>
 #include <cmath>
+#include <functional>
 
 // Template class FVector<T,N>
 // ------------------------------------------------------------------------
@@ -143,7 +144,7 @@ FVector<T, N> FVector<T, N>::operator-() const {
 template<class T, int N>
 FVector<T, N> &FVector<T, N>::operator*=(const T &val) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::multiplies<T>(), val));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, val));
     return *this;
 }
 
@@ -151,7 +152,7 @@ FVector<T, N> &FVector<T, N>::operator*=(const T &val) {
 template<class T, int N>
 FVector<T, N> &FVector<T, N>::operator/=(const T &val) {
     std::transform(this->begin(), this->end(), this->begin(),
-                   std::bind2nd(std::divides<T>(), val));
+                   std::bind(std::divides<T>(), std::placeholders::_1, val));
     return *this;
 }
 
@@ -220,7 +221,7 @@ template<class T, int N>
 FVector<T, N> operator*(const T &x, const FVector<T, N> &lhs) {
     FVector<T, N> result(lhs);
     std::transform(lhs.begin(), lhs.end(), result.begin(),
-                   std::bind2nd(std::multiplies<T>(), x));
+                   std::bind(std::multiplies<T>(), std::placeholders::_1, x));
     return result;
 }
 

--- a/src/Classic/FixedAlgebra/LinearFun.hpp
+++ b/src/Classic/FixedAlgebra/LinearFun.hpp
@@ -30,9 +30,8 @@
 #include <iomanip>
 #include <iostream>
 #include <cstring>
-#ifndef IPPL_GPLUSPLUS
 #include <functional>
-#endif
+
 // Implementation of template class LinearFun<T,N>.
 // ------------------------------------------------------------------------
 

--- a/src/Utilities/RegularExpression.cpp
+++ b/src/Utilities/RegularExpression.cpp
@@ -27,9 +27,7 @@
 #include <iostream>
 #include <new>
 #include <cstring>
-#ifndef IPPL_GPLUSPLUS
 #include <functional>
-#endif
 
 // Class RegularExpression::Expression
 // ------------------------------------------------------------------------


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "replace deprecated std::bind2nd...](https://gitlab.psi.ch/OPAL/src/merge_requests/203) |
> | **GitLab MR Number** | [203](https://gitlab.psi.ch/OPAL/src/merge_requests/203) |
> | **Date Originally Opened** | Tue, 19 Nov 2019 |
> | **Date Originally Merged** | Tue, 19 Nov 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #391 

Removes preprocessor variables:
* `POOMA_GPLUSPLUS`
* `IPPL_GPLUSPLUS`