### PR TITLE
Resolve "OPAL aborts with "number of particles per cell too low" error when running SAAMG solver"

### DIFF
--- a/src/Track/TrackRun.cpp
+++ b/src/Track/TrackRun.cpp
@@ -759,6 +759,7 @@ void TrackRun::setupFieldsolver() {
         size_t numParticles = beam->getNumberOfParticles();
 
         if (!opal->inRestartRun() && numParticles < numGridPoints
+            && Util::toUpper(fs->getType()) != std::string("SAAMG") // in SPIRAL/SAAMG we're meshing the whole domain -DW
 #ifdef ENABLE_AMR
             && !Options::amr)
 #else


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | winklehner_d |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "OPAL aborts with "number of par...](https://gitlab.psi.ch/OPAL/src/merge_requests/216) |
> | **GitLab MR Number** | [216](https://gitlab.psi.ch/OPAL/src/merge_requests/216) |
> | **Date Originally Opened** | Fri, 13 Dec 2019 |
> | **Date Originally Merged** | Fri, 13 Dec 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #406