### PR TITLE
Resolve "get rid of linker warning on macOS with clang"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,17 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options (-Warray-bounds)
     # Increase template depth for boost
     add_compile_options (-ftemplate-depth=1024)
+    # get rid of linking warning with boost. Looks like that boost
+    # is using this visibility setting.
     add_compile_options (-fvisibility=hidden)
     add_compile_options (-fvisibility-inlines-hidden)
     # Allow overloaded virtual functions (instances to be fixed in OPAL)
     #add_compile_options (-Wno-overloaded-virtual)
     if (ENABLE_OpenMP)
-	    add_compile_options (-fopenmp)
+	add_compile_options (-fopenmp)
     endif ()
+    # Not 100% clear why we need this. But without we get warning while
+    # linking with HDF5
     add_link_options (-Wl,-no_compact_unwind)
 
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "get rid of linker warning on ma...](https://gitlab.psi.ch/OPAL/src/merge_requests/262) |
> | **GitLab MR Number** | [262](https://gitlab.psi.ch/OPAL/src/merge_requests/262) |
> | **Date Originally Opened** | Thu, 16 Jan 2020 |
> | **Date Originally Merged** | Fri, 17 Jan 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #449