### PR TITLE
Merge branch '465-segmentation-fault-in-fromfile-due-to-raster-true' into 'master'

### DIFF
--- a/src/Sample/FromFile.h
+++ b/src/Sample/FromFile.h
@@ -24,9 +24,7 @@ class FromFile : public SamplingMethod
 public:
 
     FromFile(const std::string &filename, const std::string &dvarName, size_t modulo)
-        : n_m(0)
-        , counter_m(0)
-        , mod_m(modulo)
+        : mod_m(modulo)
         , filename_m(filename)
         , dvarName_m(dvarName)
     {
@@ -64,10 +62,10 @@ public:
     }
 
     void create(boost::shared_ptr<SampleIndividual>& ind, size_t i) {
-        ind->genes[i] = getNext();
+        ind->genes[i] = getNext(ind->id);
     }
 
-    void allocate(const CmdArguments_t& args, const Comm::Bundle_t& comm) {
+    void allocate(const CmdArguments_t& args, const Comm::Bundle_t& /*comm*/) {
         std::ifstream in(filename_m);
 
         if ( !in.is_open() ) {
@@ -91,36 +89,10 @@ public:
                                 "Couldn't find the dvar '" + dvarName_m + "' in the file '" + filename_m + "'");
         }
 
-        int nSamples = args->getArg<int>("nsamples", true);
-        int nMasters = args->getArg<int>("num-masters", true);
-
-        int nLocSamples = nSamples / nMasters;
-        int rest = nSamples - nMasters * nLocSamples;
-
-        int id = comm.island_id;
-        if ( id < rest )
-            nLocSamples++;
-
-        int skip = 0;
-
-        if ( rest == 0 )
-            skip = nLocSamples * id;
-        else {
-            if ( id < rest ) {
-                skip = nLocSamples * id;
-            } else {
-                skip = (nLocSamples + 1) * rest + (id - rest) * nLocSamples;
-            }
-        }
-
-        while ( skip > 0 ) {
-            skip--;
-            in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        }
-
         std::string line;
         std::getline(in, line);
-        while (nLocSamples-- > 0) {
+
+        for (unsigned int i = 0; i < globalSize_m; ++i) {
             std::istringstream iss(line);
             std::vector<std::string> numbers({std::istream_iterator<std::string>{iss},
                                               std::istream_iterator<std::string>{}});
@@ -132,10 +104,9 @@ public:
         in.close();
     }
 
-    double getNext() {
-        double sample = chain_m[n_m];
-        incrementCounter();
-
+    double getNext(unsigned int id) {
+        int idx = int(id / mod_m) % globalSize_m;
+        double sample = chain_m[idx];
         return sample;
     }
 
@@ -143,23 +114,15 @@ public:
         return globalSize_m;
     }
 
+    ~FromFile() {}
+
 private:
     std::vector<double> chain_m;
-    unsigned int n_m;
-    size_t counter_m;
     size_t mod_m;
     std::string filename_m;
     std::string dvarName_m;
 
     unsigned int globalSize_m;
-
-    void incrementCounter() {
-        ++ counter_m;
-        if (counter_m % mod_m == 0)
-            ++ n_m;
-        if (n_m >= chain_m.size())
-            n_m = 0;
-    }
 };
 
 #endif


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | frey_m |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '465-segmentation-fault-in-...](https://gitlab.psi.ch/OPAL/src/merge_requests/276) |
> | **GitLab MR Number** | [276](https://gitlab.psi.ch/OPAL/src/merge_requests/276) |
> | **Date Originally Opened** | Mon, 10 Feb 2020 |
> | **Date Originally Merged** | Mon, 10 Feb 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Segmentation fault in FromFile due to RASTER=TRUE"

Closes #465

See merge request OPAL/src!275

(cherry picked from commit b93e0537cdd58f55a477988adc9becc7652aa9e1)

3fe71d24 All masters need to read the full file otherwise we do not
61e3fb62 add missing destructor in order to avoid segmentation fault at exit