### PR TITLE
Merge branch 'patch-468' into 'Opal-2.2'

### DIFF
--- a/src/Structure/ElementPositionWriter.cpp
+++ b/src/Structure/ElementPositionWriter.cpp
@@ -35,37 +35,37 @@ void ElementPositionWriter::fillHeader() {
                         "1",
                         "quadrupole field present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("sextupole",
                         "float",
                         "1",
                         "sextupole field present",
                         std::ios_base::fixed,
-                        4);
+                        1);
     columns_m.addColumn("octupole",
                         "float",
                         "1",
                         "octupole field present",
                         std::ios_base::fixed,
-                        4);
+                        2);
     columns_m.addColumn("decapole",
                         "float",
                         "1",
                         "decapole field present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("multipole",
                         "float",
                         "1",
                         "higher multipole field present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("solenoid",
                         "float",
                         "1",
                         "solenoid field present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("rfcavity",
                         "float",
                         "1",
@@ -77,13 +77,13 @@ void ElementPositionWriter::fillHeader() {
                         "1",
                         "monitor present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("other",
                         "float",
                         "1",
                         "other element present",
                         std::ios_base::fixed,
-                        4);
+                        0);
     columns_m.addColumn("element_names",
                         "string",
                         "",

--- a/src/Structure/SDDSColumn.cpp
+++ b/src/Structure/SDDSColumn.cpp
@@ -2,6 +2,7 @@
 #include "Utilities/OpalException.h"
 
 #include <iomanip>
+#include <list>
 
 SDDSColumn::SDDSColumn(const std::string& name,
                        const std::string& type,
@@ -14,7 +15,37 @@ SDDSColumn::SDDSColumn(const std::string& name,
     writeFlags_m(flags),
     writePrecision_m(prec),
     set_m(false)
-{ }
+{
+    std::list<std::ios_base::fmtflags> numericalBase({std::ios_base::dec,
+                                                      std::ios_base::hex,
+                                                      std::ios_base::oct});
+    std::list<std::ios_base::fmtflags> floatFormat({std::ios_base::fixed,
+                                                    std::ios_base::scientific});
+    std::list<std::ios_base::fmtflags> adjustmentFlags({std::ios_base::internal,
+                                                        std::ios_base::left,
+                                                        std::ios_base::right});
+
+    // This code ensures that for each group of flags only one flag is given
+    for (std::ios_base::fmtflags flag: numericalBase) {
+        if (writeFlags_m & flag) {
+            writeFlags_m = (flag | (writeFlags_m & ~std::ios_base::basefield));
+            break;
+        }
+    }
+    for (std::ios_base::fmtflags flag: floatFormat) {
+        if (writeFlags_m & flag) {
+            writeFlags_m = (flag | (writeFlags_m & ~std::ios_base::floatfield));
+            break;
+        }
+    }
+    for (std::ios_base::fmtflags flag: adjustmentFlags) {
+        if (writeFlags_m & flag) {
+            writeFlags_m = (flag | (writeFlags_m & ~std::ios_base::adjustfield));
+            break;
+        }
+    }
+
+}
 
 
 void SDDSColumn::writeHeader(std::ostream& os,
@@ -38,7 +69,7 @@ void SDDSColumn::writeValue(std::ostream& os) const {
                             "value for column '" + name_m + "' isn't set");
     }
 
-    os.setf(writeFlags_m);
+    os.flags(writeFlags_m);
     os.precision(writePrecision_m);
     os << value_m << std::setw(10) << "\t";
     set_m = false;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch 'patch-468' into 'Opal-2.2'](https://gitlab.psi.ch/OPAL/src/merge_requests/285) |
> | **GitLab MR Number** | [285](https://gitlab.psi.ch/OPAL/src/merge_requests/285) |
> | **Date Originally Opened** | Tue, 18 Feb 2020 |
> | **Date Originally Merged** | Tue, 18 Feb 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Properly set format flags. Fixes #468

Closes #468

See merge request OPAL/src!280

(cherry picked from commit 6c8f8d0eaf868a7fa448468c4bde7b9a25afbf1b)

5c4029a0 Properly set format flags. Fixes #468
ae6eeff9 much simpler solution
b094d1aa check format flags in the header, adjust precision of written values since only 1 and -1
006d3949 a few columns are values between -1 and 1. Fix precision.
7124bc95 Add comment to constructor of SDDSColumn.