### PR TITLE
Merge branch '493-template-directory-not-found-when-path-contains-spaces' into 'OPAL-2.2'

### DIFF
--- a/optimizer/Util/CmdArguments.h
+++ b/optimizer/Util/CmdArguments.h
@@ -153,19 +153,33 @@ private:
     /// tries to retrieve command line parameter.
     /// @throws OptPilotException if parameter was not found.
     template<class T>
-    T arg(const std::string name) {
-        T t;
-        std::map<std::string, std::string>::iterator it = arguments_.find(name);
-        if(it != arguments_.end()) {
-            std::istringstream iss(arguments_[name]);
-            iss >> t;
-            return t;
-        } else {
-            throw OptPilotException("CmdArguments::getArg", "argument not found!");
-        }
-    }
+    T arg(const std::string name);
+
 };
 
 typedef boost::shared_ptr<CmdArguments> CmdArguments_t;
+
+template<class T>
+inline T CmdArguments::arg(const std::string name) {
+    T t;
+    std::map<std::string, std::string>::iterator it = arguments_.find(name);
+    if(it != arguments_.end()) {
+        std::istringstream iss(arguments_[name]);
+        iss >> t;
+        return t;
+    } else {
+        throw OptPilotException("CmdArguments::getArg", "argument not found!");
+    }
+}
+
+template<>
+inline std::string CmdArguments::arg<std::string>(const std::string name) {
+    std::map<std::string, std::string>::iterator it = arguments_.find(name);
+    if(it != arguments_.end()) {
+        return arguments_[name];
+    } else {
+        throw OptPilotException("CmdArguments::getArg", "argument not found!");
+    }
+}
 
 #endif


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '493-template-directory-not...](https://gitlab.psi.ch/OPAL/src/merge_requests/311) |
> | **GitLab MR Number** | [311](https://gitlab.psi.ch/OPAL/src/merge_requests/311) |
> | **Date Originally Opened** | Tue, 31 Mar 2020 |
> | **Date Originally Merged** | Tue, 31 Mar 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Template directory not found when path contains spaces"

Closes #493

See merge request OPAL/src!310

(cherry picked from commit 60d0264f528068a3932e75604a3dd6351ba7d410)

3c12dbba handle string arguments separately