### PR TITLE
Resolve "Runtime error on macOS: reduction MPI_SUM is not defined on MPI_INTEGER"

### DIFF
--- a/src/Solvers/ArbitraryDomain.cpp
+++ b/src/Solvers/ArbitraryDomain.cpp
@@ -384,7 +384,7 @@ void ArbitraryDomain::compute(Vector_t hr, NDIndex<3> localId){
     }
 
     int startIdx = 0;
-    MPI_Scan(&numtotal, &startIdx, 1, MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Scan(&numtotal, &startIdx, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     startIdx -= numtotal;
 
     // Build up index and coord map


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Runtime error on macOS: reducti...](https://gitlab.psi.ch/OPAL/src/merge_requests/346) |
> | **GitLab MR Number** | [346](https://gitlab.psi.ch/OPAL/src/merge_requests/346) |
> | **Date Originally Opened** | Tue, 28 Apr 2020 |
> | **Date Originally Merged** | Wed, 29 Apr 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #526