### PR TITLE
Resolve "missing include of Physics/Physics.h in tests/classic_src/AbsBeamline/SBend3DTest.cpp"

### DIFF
--- a/tests/classic_src/AbsBeamline/SBend3DTest.cpp
+++ b/tests/classic_src/AbsBeamline/SBend3DTest.cpp
@@ -36,6 +36,7 @@
 #include "Utilities/LogicalError.h"
 #include "Structure/BoundaryGeometry.h"
 #include "AbsBeamline/SBend3D.h"
+#include "Physics/Physics.h"
 
 #include "opal_test_utilities/SilenceTest.h"
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "missing include of Physics/Phys...](https://gitlab.psi.ch/OPAL/src/merge_requests/387) |
> | **GitLab MR Number** | [387](https://gitlab.psi.ch/OPAL/src/merge_requests/387) |
> | **Date Originally Opened** | Mon, 22 Jun 2020 |
> | **Date Originally Merged** | Mon, 22 Jun 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #556