### PR TITLE
<cstring> is missing in two source files

### DIFF
--- a/ippl/src/Utility/DiscMeta.cpp
+++ b/ippl/src/Utility/DiscMeta.cpp
@@ -30,6 +30,7 @@
 #include "Utility/IpplInfo.h"
 #include "Utility/Inform.h"
 
+#include <cstring>
 
 ///////////////////////////////////////////////////////////////////////////
 // Constructor: read and parse the given meta file

--- a/src/Structure/IpplInfoWrapper.cpp
+++ b/src/Structure/IpplInfoWrapper.cpp
@@ -4,6 +4,8 @@
 
 #include "Structure/IpplInfoWrapper.h"
 
+#include <cstring>
+
 IpplInfoWrapper::IpplInfoWrapper(const std::string &inputFileName, int infoLevel, int warnLevel, MPI_Comm comm) {
     std::string infoLevelStr = std::to_string(infoLevel);
     std::string warnLevelStr = std::to_string(warnLevel);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [<cstring> is missing in two source files](https://gitlab.psi.ch/OPAL/src/merge_requests/443) |
> | **GitLab MR Number** | [443](https://gitlab.psi.ch/OPAL/src/merge_requests/443) |
> | **Date Originally Opened** | Sat, 3 Oct 2020 |
> | **Date Originally Merged** | Tue, 6 Oct 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_