### PR TITLE
Merge branch '609-transversely-shifted-distribution-in-temporal-monitors' into 'master'

### DIFF
--- a/src/Classic/AbsBeamline/Monitor.cpp
+++ b/src/Classic/AbsBeamline/Monitor.cpp
@@ -104,7 +104,7 @@ bool Monitor::applyToReferenceParticle(const Vector_t &R,
             dt * (R(2) + P(2) * recpgamma) > dt * middle) {
             double frac = (middle - R(2)) / (P(2) * recpgamma);
             double time = t + frac * dt;
-            Vector_t dR = (0.5 + frac) * P * recpgamma;
+            Vector_t dR = frac * P * recpgamma;
             double ds = euclidean_norm(dR);
             lossDs_m->addReferenceParticle(csTrafoGlobal2Local_m.transformFrom(R + dR),
                                            csTrafoGlobal2Local_m.rotateFrom(P),
@@ -117,9 +117,12 @@ bool Monitor::applyToReferenceParticle(const Vector_t &R,
 
                 for (unsigned int i = 0; i < localNum; ++ i) {
                     const double recpgamma = Physics::c * dt / Util::getGamma(RefPartBunch_m->P[i]);
-                    lossDs_m->addParticle(RefPartBunch_m->R[i] + frac * RefPartBunch_m->P[i] * recpgamma - halfLength_s,
-                                          RefPartBunch_m->P[i], RefPartBunch_m->ID[i],
-                                          time, 0);
+                    Vector_t shift = frac * recpgamma * RefPartBunch_m->P[i] - Vector_t(0, 0, middle);
+                    lossDs_m->addParticle(RefPartBunch_m->R[i] + shift,
+                                          RefPartBunch_m->P[i],
+                                          RefPartBunch_m->ID[i],
+                                          time,
+                                          0);
                 }
                 OpalData::OPENMODE openMode;
                 if (numPassages_m > 0) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '609-transversely-shifted-d...](https://gitlab.psi.ch/OPAL/src/merge_requests/446) |
> | **GitLab MR Number** | [446](https://gitlab.psi.ch/OPAL/src/merge_requests/446) |
> | **Date Originally Opened** | Tue, 6 Oct 2020 |
> | **Date Originally Merged** | Tue, 6 Oct 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Transversely shifted distribution in temporal monitors"

Closes #609

See merge request OPAL/src!444

(cherry picked from commit 5ff2f5ae628448c78368b7df4a88b3ea348b05e6)

3f0bdc0a get rid of shift in transverse direction if type of monitor is temporal
702edd51 fix position of reference particle in temporal monitor