### PR TITLE
Merge branch '635-get-correct-output-of-value-option-autophase' into 'OPAL-2.4'

### DIFF
--- a/src/BasicActions/Option.cpp
+++ b/src/BasicActions/Option.cpp
@@ -18,6 +18,7 @@
 // along with OPAL. If not, see <https://www.gnu.org/licenses/>.
 //
 #include "BasicActions/Option.h"
+#include "AbstractObjects/OpalData.h"
 #include "Attributes/Attributes.h"
 #include "Parser/FileStream.h"
 #include "Utilities/Options.h"
@@ -65,7 +66,7 @@ namespace {
         AUTOPHASE,
         SURFDUMPFREQ,
         NUMBLOCKS,
-        RECYCLEBLOCKS,
+         RECYCLEBLOCKS,
         NLHS,
         CZERO,
         RNGTYPE,
@@ -491,6 +492,11 @@ void Option::execute() {
     if(Attributes::getBool(itsAttr[TELL])) {
         *gmsg << "\nCurrent settings of options:\n" << *this << endl;
     }
+
+    Option* main = dynamic_cast<Option*>(OpalData::getInstance()->find("OPTION"));
+    if (main) {
+        main->update(itsAttr);
+    }
 }
 
 void Option::handlePsDumpFrame(const std::string &dumpFrame) {
@@ -517,5 +523,11 @@ std::string DumpFrameToString(DumpFrame df) {
     case GLOBAL:
     default:
         return std::string("GLOBAL");
+    }
+}
+
+void Option::update(const std::vector<Attribute>& othersAttributes) {
+    for (int i = 0; i < SIZE; ++ i) {
+        itsAttr[i] = othersAttributes[i];
     }
 }

--- a/src/BasicActions/Option.h
+++ b/src/BasicActions/Option.h
@@ -39,6 +39,7 @@ public:
 
 private:
     void handlePsDumpFrame(const std::string &dumpFrame);
+    void update(const std::vector<Attribute>&);
 
     // Not implemented.
     Option(const Option &);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '635-get-correct-output-of-...](https://gitlab.psi.ch/OPAL/src/merge_requests/473) |
> | **GitLab MR Number** | [473](https://gitlab.psi.ch/OPAL/src/merge_requests/473) |
> | **Date Originally Opened** | Sun, 31 Jan 2021 |
> | **Date Originally Merged** | Mon, 1 Feb 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Get correct output of VALUE, OPTION->AUTOPHASE"

Closes #635

See merge request OPAL/src!472

(cherry picked from commit 49fc5b281286529726f5b6a8c01671c1b873a6de)

64a1faee update the attribute values of OPTION