### PR TITLE
Disable periodic BC's until its is supported by IPPL

### DIFF
--- a/src/Structure/FieldSolver.cpp
+++ b/src/Structure/FieldSolver.cpp
@@ -462,6 +462,10 @@ void FieldSolver::initSolver(PartBunchBase<double, 3> *b) {
         bcz = Attributes::getString(itsAttr[BCFFTZ]);
     }
 
+    if (bcz == "PERIODIC" || bcx == "PERIODIC" || bcy == "PERIODIC") {
+        throw OpalException("FieldSolver::init", "Periodic boundaries aren't supported at the moment");
+    }
+
     if ( isAmrSolverType() ) {
         Inform m("FieldSolver::initAmrSolver");
         fsType_m = "AMR";


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Disable periodic BC's until its is suppo...](https://gitlab.psi.ch/OPAL/src/merge_requests/498) |
> | **GitLab MR Number** | [498](https://gitlab.psi.ch/OPAL/src/merge_requests/498) |
> | **Date Originally Opened** | Wed, 9 Jun 2021 |
> | **Date Originally Closed** | Thu, 10 Jun 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

Throw an exception if the user tries to simulate with a periodic field solver. For #119