### PR TITLE
Resolve "Increase C++ Standard to c++17"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message (STATUS "The underlying C++ compiler is: ${CMAKE_CXX_COMPILER}")
 
 option (ENABLE_OpenMP "Use hybrid parallelism MPI-OpenMP" OFF)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Increase C++ Standard to c++17"](https://gitlab.psi.ch/OPAL/src/merge_requests/504) |
> | **GitLab MR Number** | [504](https://gitlab.psi.ch/OPAL/src/merge_requests/504) |
> | **Date Originally Opened** | Thu, 10 Jun 2021 |
> | **Date Originally Merged** | Fri, 25 Jun 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #607 

OPAL compiles without problem with -std=C++17. Tested with the current and an updated toolchain.