### PR TITLE
Resolve "Replace in c++17 removed std::unary_function and std::binary_function"

### DIFF
--- a/ippl/src/Utility/vmap.h
+++ b/ippl/src/Utility/vmap.h
@@ -63,10 +63,8 @@ public:
   typedef Key key_type;
   typedef std::pair<Key, T> value_type;
   typedef Compare key_compare;
-    
-  class value_compare : public 
 
-std::binary_function<value_type, value_type, bool>
+  class value_compare
   {
   private:
     Compare comp;

--- a/src/Algorithms/ParallelCyclotronTracker.cpp
+++ b/src/Algorithms/ParallelCyclotronTracker.cpp
@@ -1532,7 +1532,7 @@ bool ParallelCyclotronTracker::RFkick(RFCavity * rfcavity, const double t, const
 }
 
 
-struct adder : public std::unary_function<double, void> {
+struct adder {
     adder() : sum(0) {}
     double sum;
     void operator()(double x) { sum += x; }

--- a/src/Algorithms/lomb.h
+++ b/src/Algorithms/lomb.h
@@ -17,7 +17,7 @@ typedef struct {
 typedef std::vector<LOMB_TYPE>::const_iterator CI_lt;
 typedef std::vector<double>::const_iterator CI_vd;
 
-class Lomb_eq : public std::unary_function<LOMB_TYPE, bool> {
+class Lomb_eq {
     double b;
 public:
     explicit Lomb_eq(const double &a) : b(a) {}

--- a/src/Classic/Algorithms/PartBins.h
+++ b/src/Classic/Algorithms/PartBins.h
@@ -171,7 +171,7 @@ inline Inform &operator<<(Inform &os, PartBins &p) {
 }
 
 
-class AscendingLocationSort: public std::binary_function< std::vector<double>, std::vector<double>, bool> {
+class AscendingLocationSort {
 public:
     AscendingLocationSort(int direction = 0): direction_m(direction)
     {;}
@@ -183,7 +183,7 @@ private:
     int direction_m;
 };
 
-class DescendingLocationSort: public std::binary_function< std::vector<double>, std::vector<double>, bool> {
+class DescendingLocationSort {
 public:
     DescendingLocationSort(int direction = 0): direction_m(direction)
     {;}

--- a/src/Classic/Structure/LossDataSink.h
+++ b/src/Classic/Structure/LossDataSink.h
@@ -63,7 +63,7 @@ struct SetStatistics {
 
 namespace std {
     template<>
-    struct less<SetStatistics> : binary_function<SetStatistics, SetStatistics, bool> {
+    struct less<SetStatistics> {
         bool operator() (const SetStatistics& x, const SetStatistics& y) const {
             return x.spos_m < y.spos_m;
         }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @https://intranet.psi.ch/main/jochemsnuverink |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Replace in c++17 removed std::u...](https://gitlab.psi.ch/OPAL/src/merge_requests/511) |
> | **GitLab MR Number** | [511](https://gitlab.psi.ch/OPAL/src/merge_requests/511) |
> | **Date Originally Opened** | Tue, 6 Jul 2021 |
> | **Date Originally Merged** | Wed, 7 Jul 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #664

The inheritance can simply be removed: https://stackoverflow.com/a/33115140/5453374