### PR TITLE
Merge branch...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,11 +61,6 @@ add_compile_options (-Werror)
 add_compile_options (-funroll-loops)
 add_compile_options (-fstrict-aliasing)
 
-# An error in Trilinos/12.18.1 causes
-# -Waggressive-loop-optimizations with -O3 optimization.
-# See issue 587 and corresponding merge request 415.
-add_compile_options (-fno-aggressive-loop-optimizations)
-
 option (USE_STATIC_LIBRARIES "Link with static libraries if available" ON)
 if (NOT ${USE_STATIC_LIBRARIES})
     add_compile_options (-fPIE -fPIC)
@@ -98,6 +93,12 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     endif ()
 
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    # An error in Trilinos/12.18.1 causes
+    # -Waggressive-loop-optimizations with -O3 optimization.
+    # See issue 587 and corresponding merge request 415.
+    # Clang does not support this flag!
+    add_compile_options (-fno-aggressive-loop-optimizations)
+
     if (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "4.7.3")
         message (FATAL_ERROR "To build OPAL you need GCC version 4.7.3 or greater")
     endif ()


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch...](https://gitlab.psi.ch/OPAL/src/merge_requests/535) |
> | **GitLab MR Number** | [535](https://gitlab.psi.ch/OPAL/src/merge_requests/535) |
> | **Date Originally Opened** | Fri, 27 Aug 2021 |
> | **Date Originally Merged** | Fri, 27 Aug 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Merge branch '678-clang-does-not-support-option-fno-aggressive-loop-optimizations' into 'OPAL-2021.1'

Resolve "Clang does not support option -fno-aggressive-loop-optimizations"

See merge request OPAL/src!532

(cherry picked from commit 724ce2c8336db79bec0348a8beaaf9fe8636668e)

d3dab495 Clang does not support option -fno-aggressive-loop-optimizations