### PR TITLE
Merge branch '676-clang-12-compiler-warnings-on-macos' into 'OPAL-2021.1'

### DIFF
--- a/ippl/src/AppTypes/AntiSymTenzor.h
+++ b/ippl/src/AppTypes/AntiSymTenzor.h
@@ -379,6 +379,10 @@ public:
   // Operators
   
   Element_t operator()(unsigned int i, unsigned int j) const {
+    // PAssert and PAssert_EQ are macros. They are defined empty, if we
+    // compile for production. i and j are unused in this case. The
+    // following statement suppress the 'unused' warning.
+    (void)i; (void)j;
     PAssert_EQ(i, j);
     return T(0.0);
   }
@@ -390,6 +394,7 @@ public:
   }
 
   AssignProxy operator()(unsigned int i, unsigned int j) {
+    (void)i; (void)j;
     PAssert_EQ(i, j);
     return AssignProxy(AntiSymTenzor<T,1>::Zero, 0);
   }
@@ -401,6 +406,7 @@ public:
   }
 
   Element_t operator[](unsigned int i) const { 
+    (void)i;
     PAssert (i == 0);
     return AntiSymTenzor<T,1>::Zero;
   }
@@ -408,6 +414,7 @@ public:
   // These are the same as operator[] but with () instead:
 
   Element_t operator()(unsigned int i) const { 
+    (void)i;
     PAssert (i == 0);
     return AntiSymTenzor<T,1>::Zero;
   }

--- a/ippl/test/particle/p3m3dHeating.cpp
+++ b/ippl/test/particle/p3m3dHeating.cpp
@@ -474,9 +474,8 @@ public:
         h5_prop_t props = H5CreateFileProp ();
         MPI_Comm comm = Ippl::getComm();
         h5_err_t h5err = H5SetPropFileMPIOCollective (props, &comm);
-#if defined (NDEBUG)
+        // suppress unused warning if we compile for production
         (void)h5err;
-#endif
         PAssert (h5err != H5_ERR);
         H5f_m = H5OpenFile (fn.c_str(), H5_O_RDONLY, props);
         PAssert (H5f_m != (h5_file_t)H5_ERR);

--- a/ippl/test/particle/p3m3dMicrobunching.cpp
+++ b/ippl/test/particle/p3m3dMicrobunching.cpp
@@ -465,9 +465,8 @@ class ChargedParticles : public IpplParticleBase<PL> {
                     MPI_Comm comm = Ippl::getComm();
                     h5_err_t h5err = H5SetPropFileMPIOCollective (props, &comm);
                     PAssert (h5err != H5_ERR);
-#ifdef NDEBUG
-		    (void) h5err;  // without this line we get an unused variable warning
-#endif
+                    // suppress unused warning if we compile for production
+		    (void) h5err;
                     H5f_m = H5OpenFile(fn.c_str(), H5_O_WRONLY, props);
                 }
 

--- a/src/BasicActions/Option.h
+++ b/src/BasicActions/Option.h
@@ -39,6 +39,7 @@ public:
 
 private:
     void handlePsDumpFrame(const std::string& dumpFrame);
+    using Object::update;
     void update(const std::vector<Attribute>&);
 
     // Not implemented.

--- a/src/Classic/AbsBeamline/Undulator.h
+++ b/src/Classic/AbsBeamline/Undulator.h
@@ -42,6 +42,7 @@ public:
 
     virtual void initialise(PartBunchBase<double, 3>* bunch, double& startField, double& endField);
 
+    using Component::apply;
     void apply(PartBunchBase<double, 3>* itsBunch, CoordinateSystemTrafo const& refToLocalCSTrafo);
 
     virtual void finalise();

--- a/src/Solvers/ArbitraryDomain.h
+++ b/src/Solvers/ArbitraryDomain.h
@@ -49,12 +49,12 @@ public:
     ~ArbitraryDomain();
 
     /// queries if a given (x,y,z) coordinate lies inside the domain
-    bool isInside(int idx, int idy, int idz) const {
+    bool isInside(int idx, int idy, int idz) const override {
         return isInsideMap_m.at(toCoordIdx(idx, idy, idz));
     }
 
     // calculates intersection with rotated and shifted geometry
-    void compute(Vector_t hr, NDIndex<3> localId);
+    void compute(Vector_t hr, NDIndex<3> localId) override;
 
 private:
     BoundaryGeometry *bgeom_m;
@@ -87,11 +87,11 @@ private:
     }
 
     // Conversion from (x,y,z) to index on the 3D grid
-    int indexAccess(int x, int y, int z) const {
+    int indexAccess(int x, int y, int z) const override {
         return idxMap_m.at(toCoordIdx(x, y, z));
     }
 
-    int coordAccess(int idx) const {
+    int coordAccess(int idx) const override {
         return coordMap_m.at(idx);
     }
 

--- a/src/Solvers/BoxCornerDomain.h
+++ b/src/Solvers/BoxCornerDomain.h
@@ -93,14 +93,14 @@ public:
     }
 
     /// queries if a given (x,y,z) coordinate lies inside the domain
-    inline bool isInside(int x, int y, int z) const {
+    inline bool isInside(int x, int y, int z) const override {
         const double xx = (x - (nr_m[0] - 1) / 2.0) * hr_m[0];
         const double yy = (y - (nr_m[1] - 1) / 2.0) * hr_m[1];
         const double b = getB(z * hr_m[2]);
         return (xx < getXRangeMax() && yy < b && z >= 0 && z < nr_m[2]);
     }
 
-    void compute(Vector_t hr, NDIndex<3> localId);
+    void compute(Vector_t hr, NDIndex<3> localId) override;
 
 private:
 
@@ -139,11 +139,11 @@ private:
     }
 
     /// conversion from (x,y,z) to index on the 3D grid
-    int indexAccess(int x, int y, int z) const {
+    int indexAccess(int x, int y, int z) const override {
         return idxMap_m.at(toCoordIdx(x, y, z));
     }
 
-    int coordAccess(int idx) const {
+    int coordAccess(int idx) const override {
         return coordMap_m.at(idx);
     }
 

--- a/src/Solvers/EllipticDomain.h
+++ b/src/Solvers/EllipticDomain.h
@@ -45,7 +45,7 @@ public:
     ~EllipticDomain();
 
     /// queries if a given (x,y,z) coordinate lies inside the domain
-    bool isInside(int x, int y, int z) const {
+    bool isInside(int x, int y, int z) const override {
         double xx = getXRangeMin() + hr_m[0] * (x + 0.5);
         double yy = getYRangeMin() + hr_m[1] * (y + 0.5);
 
@@ -56,7 +56,7 @@ public:
     }
 
     /// calculates intersection
-    void compute(Vector_t hr, NDIndex<3> localId);
+    void compute(Vector_t hr, NDIndex<3> localId) override;
 
 private:
 
@@ -74,11 +74,11 @@ private:
     int toCoordIdx(int x, int y) const { return y * nr_m[0] + x; }
 
     /// conversion from (x,y,z) to index on the 3D grid
-    int indexAccess(int x, int y, int z) const {
+    int indexAccess(int x, int y, int z) const override {
         return idxMap_m.at(toCoordIdx(x, y)) + z * getNumXY();
     }
 
-    int coordAccess(int idx) const {
+    int coordAccess(int idx) const override {
         int ixy = idx % getNumXY();
         return coordMap_m.at(ixy);
     }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '676-clang-12-compiler-warn...](https://gitlab.psi.ch/OPAL/src/merge_requests/536) |
> | **GitLab MR Number** | [536](https://gitlab.psi.ch/OPAL/src/merge_requests/536) |
> | **Date Originally Opened** | Fri, 27 Aug 2021 |
> | **Date Originally Merged** | Fri, 27 Aug 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "Clang 12 compiler warnings on macOS"

See merge request OPAL/src!530

(cherry picked from commit 9eb107d85f298aae1f00cc729916e7b65cad84a7)

e924817e Fixes for several Clang warnings
9e9f02a4 Merge branch...
fadcf4b0 Merge branch '677-linking-issues-on-macos' into 676-clang-12-compiler-warnings-on-macos
60176049 Improve fixes for Clang warnings