### PR TITLE
Merge branch '679-opal-header-is-not-printed-in-interactive-mode' into 'OPAL-2021.1'

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -215,6 +215,7 @@ int main(int argc, char *argv[]) {
         }
 
         if(argc <= 1) {
+            ::printStdoutHeader();
             // Run commands from standard input
             parser.run(new TerminalStream("OPAL"));
         } else {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Merge branch '679-opal-header-is-not-pri...](https://gitlab.psi.ch/OPAL/src/merge_requests/537) |
> | **GitLab MR Number** | [537](https://gitlab.psi.ch/OPAL/src/merge_requests/537) |
> | **Date Originally Opened** | Fri, 27 Aug 2021 |
> | **Date Originally Merged** | Fri, 27 Aug 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Resolve "OPAL header is not printed in interactive mode"

See merge request OPAL/src!534

(cherry picked from commit d2009a3b36fc7d526b8347f3ae41ddfa708e5328)

20db1d03 Print OPAL header in interactice mode