### PR TITLE
Resolve 'Output file names for LossDataSink can't have prefixed dots'

### DIFF
--- a/src/Classic/AbsBeamline/ElementBase.cpp
+++ b/src/Classic/AbsBeamline/ElementBase.cpp
@@ -67,6 +67,8 @@
 #include "Solvers/WakeFunction.h"
 #include "Structure/BoundaryGeometry.h"
 
+#include <boost/filesystem.hpp>
+
 #include <string>
 
 ElementBase::ElementBase():
@@ -146,7 +148,8 @@ std::string ElementBase::getOutputFN() const {
     if (outputfn_m.empty()) {
         return getName();
     } else {
-        return outputfn_m.substr(0, outputfn_m.rfind("."));
+        boost::filesystem::path filePath(outputfn_m);
+        return filePath.replace_extension().native();
     }
 }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | kraus |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve 'Output file names for LossDataS...](https://gitlab.psi.ch/OPAL/src/merge_requests/543) |
> | **GitLab MR Number** | [543](https://gitlab.psi.ch/OPAL/src/merge_requests/543) |
> | **Date Originally Opened** | Wed, 13 Oct 2021 |
> | **Date Originally Merged** | Thu, 14 Oct 2021 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #685