### PR TITLE
Resolve "Redefine heavy ion beams"

### DIFF
--- a/src/Classic/Physics/ParticleProperties.cpp
+++ b/src/Classic/Physics/ParticleProperties.cpp
@@ -94,6 +94,6 @@ const std::map<ParticleType, double> ParticleProperties::particleCharge_m = {
     {ParticleType::H3P,         1.0},
     {ParticleType::ALPHA,       2.0},
     {ParticleType::CARBON,      6.0},
-    {ParticleType::XENON,      20.0},
-    {ParticleType::URANIUM,    35.0}
+    {ParticleType::XENON,      54.0},
+    {ParticleType::URANIUM,    92.0}
 };

--- a/src/Classic/Physics/Physics.h
+++ b/src/Classic/Physics/Physics.h
@@ -101,14 +101,14 @@ namespace Physics {
     /// The charge of proton
     constexpr double z_p        = 1;
 
-    /// The carbon rest mass in GeV
-    constexpr double m_c        = 12 * amu;
+    /// The carbon-12 (fully-stripped) rest mass in GeV
+    constexpr double m_c        = 11.9967074146787 * amu;
 
     /// The H- rest mass in GeV
     constexpr double m_hm       = 1.00837 * amu;
 
-    /// The uranium rest mass in GeV
-    constexpr double m_u        = 238.050787 * amu;
+    /// The uranium-238 (fully-stripped) rest mass in GeV
+    constexpr double m_u        = 237.999501 * amu;
 
     /// The muon rest mass in GeV
     constexpr double m_mu       = 0.1056583755;
@@ -116,8 +116,8 @@ namespace Physics {
     /// The deuteron rest mass in GeV
     constexpr double m_d        = 2.013553212745 * amu;
 
-    /// The xenon rest mass in GeV
-    constexpr double m_xe       = 124 * amu;
+    /// The xenon-129 (fully-stripped) rest mass in GeV
+    constexpr double m_xe       = 128.87494026 * amu;
 
     /// The alpha particle rest mass in GeV
     constexpr double m_alpha    = 4.001506179127 * amu;


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | ext-calvo_p |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Redefine heavy ion beams"](https://gitlab.psi.ch/OPAL/src/merge_requests/560) |
> | **GitLab MR Number** | [560](https://gitlab.psi.ch/OPAL/src/merge_requests/560) |
> | **Date Originally Opened** | Mon, 27 Dec 2021 |
> | **Date Originally Merged** | Mon, 10 Jan 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #699 

The mass of the ions is calculated by subtracting the mass of the electrons and the [binding energy](https://physics.nist.gov/PhysRefData/ASD/ionEnergy.html) from the [atomic mass](https://www-nds.iaea.org/amdc/).