### PR TITLE
Resolve "boost::filesystem::extension() is deprecated in new boost versions"

### DIFF
--- a/src/Optimize/OpalSimulation.cpp
+++ b/src/Optimize/OpalSimulation.cpp
@@ -656,7 +656,7 @@ void OpalSimulation::cleanUp(const std::vector<std::string>& keep) {
         {
             fs::directory_iterator it{p};
             while (it != fs::directory_iterator{}) {
-                std::string extension = Util::toUpper(fs::extension(it->path().filename()));
+                std::string extension = Util::toUpper(it->path().extension().string());
 
                 // remove .
                 extension.erase(0, 1);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "boost::filesystem::extension() ...](https://gitlab.psi.ch/OPAL/src/merge_requests/612) |
> | **GitLab MR Number** | [612](https://gitlab.psi.ch/OPAL/src/merge_requests/612) |
> | **Date Originally Opened** | Tue, 4 Apr 2023 |
> | **Date Originally Merged** | Wed, 5 Apr 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #754