### PR TITLE
Resolve "Tpetra CsrMatrix::getNodeNumElements() is deprecated"

### DIFF
--- a/src/Solvers/MGPoissonSolver.cpp
+++ b/src/Solvers/MGPoissonSolver.cpp
@@ -533,7 +533,7 @@ void MGPoissonSolver::ComputeStencil(Vector_t /*hr*/, Teuchos::RCP<TpetraVector_
 # pragma clang diagnostic push
 # pragma clang diagnostic warning "-Wdeprecated-declarations"
 #endif
-    int NumMyElements = map_p->getNodeNumElements();
+    int NumMyElements = map_p->getLocalNumElements();
 #if defined(__clang__)
 # pragma clang diagnostic pop
 #endif
@@ -611,7 +611,7 @@ void MGPoissonSolver::printLoadBalanceStats() {
 # pragma clang diagnostic push
 # pragma clang diagnostic warning "-Wdeprecated-declarations"
 #endif
-    size_t myNumPart = map_p->getNodeNumElements();
+    size_t myNumPart = map_p->getLocalNumElements();
     size_t NumPart = map_p->getGlobalNumElements() * 1.0 / comm_mp->getSize();
 #if defined(__clang__)
 # pragma clang diagnostic pop


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | gsell |
> | **GitLab Project** | [OPAL/src](https://gitlab.psi.ch/OPAL/src) |
> | **GitLab Merge Request** | [Resolve "Tpetra CsrMatrix::getNodeNumEle...](https://gitlab.psi.ch/OPAL/src/merge_requests/613) |
> | **GitLab MR Number** | [613](https://gitlab.psi.ch/OPAL/src/merge_requests/613) |
> | **Date Originally Opened** | Tue, 4 Apr 2023 |
> | **Date Originally Merged** | Wed, 5 Apr 2023 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Closes #755