### PR TITLE
Fix conic aperture interpolation

### DIFF
--- a/src/Classic/AbsBeamline/ElementBase.cpp
+++ b/src/Classic/AbsBeamline/ElementBase.cpp
@@ -292,7 +292,7 @@ bool ElementBase::isInsideTransverse(const Vector_t &r) const
     if (aperture_m.first == ApertureType::CONIC_RECTANGULAR ||
         aperture_m.first == ApertureType::CONIC_ELLIPTICAL) {
         const double length = getElementLength();
-        if (std::abs(length) > 0.0) {
+        if (length > 0.0) {
             Vector_t rRelativeToBegin = getEdgeToBegin().transformTo(r);
             double fractionLength = rRelativeToBegin(2) / length;
             fractionLength = std::clamp(fractionLength, 0.0, 1.0);

--- a/src/Classic/AbsBeamline/ElementBase.cpp
+++ b/src/Classic/AbsBeamline/ElementBase.cpp
@@ -291,9 +291,14 @@ bool ElementBase::isInsideTransverse(const Vector_t &r) const
     double factor = 1.0;
     if (aperture_m.first == ApertureType::CONIC_RECTANGULAR ||
         aperture_m.first == ApertureType::CONIC_ELLIPTICAL) {
-        Vector_t rRelativeToBegin = getEdgeToBegin().transformTo(r);
-        double fractionLength = rRelativeToBegin(2) / getElementLength();
-        factor = fractionLength * aperture_m.second[2];
+        const double length = getElementLength();
+        if (std::abs(length) > 0.0) {
+            Vector_t rRelativeToBegin = getEdgeToBegin().transformTo(r);
+            double fractionLength = rRelativeToBegin(2) / length;
+            fractionLength = std::clamp(fractionLength, 0.0, 1.0);
+            // Interpolate aperture scaling from begin (1.0) to end (aperture_m.second[2]).
+            factor = 1.0 + fractionLength * (aperture_m.second[2] - 1.0);
+        }
     }
 
     switch(aperture_m.first) {

--- a/src/Elements/OpalElement.cpp
+++ b/src/Elements/OpalElement.cpp
@@ -182,11 +182,11 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = retvalue.second[0];
                 retvalue.second[2] = std::stod(match[2]);
-                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
             }
+            validateConicScale(retvalue.second[2], arguments);
         }
 
         return retvalue;
@@ -200,11 +200,9 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
 
             try {
                 size_t sz = 0;
-
                 retvalue.second[0] = width2HalfWidth * std::stod(arguments, &sz);
                 sz = arguments.find_first_of(",", sz) + 1;
                 retvalue.second[1] = width2HalfWidth * std::stod(arguments.substr(sz));
-
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
@@ -212,16 +210,15 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
 
         } else {
             retvalue.first = ApertureType::CONIC_RECTANGULAR;
-
             try {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = width2HalfWidth * std::stod(match[2]);
                 retvalue.second[2] = std::stod(match[3]);
-                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
             }
+            validateConicScale(retvalue.second[2], arguments);
         }
 
         return retvalue;
@@ -231,7 +228,6 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
         std::string arguments = match[1];
         if (!std::regex_search(arguments, match, twoArguments)) {
             retvalue.first = ApertureType::ELLIPTICAL;
-
             try {
                 retvalue.second[0] = width2HalfWidth * std::stod(arguments);
                 retvalue.second[1] = retvalue.second[0];
@@ -242,16 +238,15 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
 
         } else {
             retvalue.first = ApertureType::CONIC_ELLIPTICAL;
-
             try {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = retvalue.second[0];
                 retvalue.second[2] = std::stod(match[2]);
-                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
             }
+            validateConicScale(retvalue.second[2], arguments);
         }
 
         return retvalue;
@@ -262,7 +257,6 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
 
         if (!std::regex_search(arguments, match, threeArguments)) {
             retvalue.first = ApertureType::ELLIPTICAL;
-
             try {
                 size_t sz = 0;
 
@@ -277,16 +271,15 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
 
         } else {
             retvalue.first = ApertureType::CONIC_ELLIPTICAL;
-
             try {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = width2HalfWidth * std::stod(match[2]);
                 retvalue.second[2] = std::stod(match[3]);
-                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
             }
+            validateConicScale(retvalue.second[2], arguments);
         }
 
         return retvalue;

--- a/src/Elements/OpalElement.cpp
+++ b/src/Elements/OpalElement.cpp
@@ -147,12 +147,20 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
     std::regex circle("circle *\\((.*)\\)", std::regex::icase);
     std::regex ellipse("ellipse *\\((.*)\\)", std::regex::icase);
 
-    std::regex twoArguments("([^,]*),([^,]*)");
-    std::regex threeArguments("([^,]*),([^,]*),([^,]*)");
+    std::regex twoArguments("^\\s*([^,]+)\\s*,\\s*([^,]+)\\s*$");
+    std::regex threeArguments("^\\s*([^,]+)\\s*,\\s*([^,]+)\\s*,\\s*([^,]+)\\s*$");
 
     std::smatch match;
 
     const double width2HalfWidth = 0.5;
+
+    auto validateConicScale = [&](double scale, const std::string& arguments) {
+        if (!(scale > 0.0)) {
+            throw OpalException("OpalElement::getApert()",
+                                "invalid conic aperture scale in '" + arguments +
+                                "': expected positive real value");
+        }
+    };
 
     if (std::regex_search(aperture, match, square)) {
         std::string arguments = match[1];
@@ -174,6 +182,7 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = retvalue.second[0];
                 retvalue.second[2] = std::stod(match[2]);
+                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
@@ -208,6 +217,7 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = width2HalfWidth * std::stod(match[2]);
                 retvalue.second[2] = std::stod(match[3]);
+                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
@@ -237,6 +247,7 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = retvalue.second[0];
                 retvalue.second[2] = std::stod(match[2]);
+                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");
@@ -271,6 +282,7 @@ std::pair<ApertureType, std::vector<double> > OpalElement::getApert() const {
                 retvalue.second[0] = width2HalfWidth * std::stod(match[1]);
                 retvalue.second[1] = width2HalfWidth * std::stod(match[2]);
                 retvalue.second[2] = std::stod(match[3]);
+                validateConicScale(retvalue.second[2], arguments);
             } catch (const std::exception &ex) {
                 throw OpalException("OpalElement::getApert()",
                                     "could not convert '" + arguments + "' to doubles");

--- a/tests/opal_src/Elements/CMakeLists.txt
+++ b/tests/opal_src/Elements/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (_SRCS
     OpalAsymmetricEngeTest.cpp
+    OpalDriftTest.cpp
     OpalEngeTest.cpp
     OpalOffsetTest.cpp
     OpalOutputPlaneTest.cpp

--- a/tests/opal_src/Elements/OpalDriftTest.cpp
+++ b/tests/opal_src/Elements/OpalDriftTest.cpp
@@ -1,0 +1,178 @@
+//
+// Unit tests for OpalDrift element definition
+//
+// Copyright (c) 2026
+// All rights reserved.
+//
+// This file is part of OPAL.
+//
+// OPAL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License
+// along with OPAL. If not, see <https://www.gnu.org/licenses/>.
+//
+#include "gtest/gtest.h"
+
+#include "Attributes/Attributes.h"
+#include "Elements/OpalDrift.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::unique_ptr<OpalDrift> makeDrift(const std::optional<std::string>& aperture) {
+    auto drift = std::make_unique<OpalDrift>();
+    Attributes::setReal(*drift->findAttribute("L"), 2.0);
+    if (aperture.has_value()) {
+        Attributes::setString(*drift->findAttribute("APERTURE"), aperture.value());
+    }
+    drift->update();
+    return drift;
+}
+
+}  // namespace
+
+TEST(OpalDriftTest, CircleDefaultsMatchDefaultApertureBehaviour) {
+    auto noAperture = makeDrift(std::nullopt);
+    auto circle = makeDrift("CIRCLE(1)");
+    auto conicCircle = makeDrift("CIRCLE(1,1)");
+
+    ElementBase* noApertureElement = noAperture->getElement();
+    ElementBase* circleElement = circle->getElement();
+    ElementBase* conicCircleElement = conicCircle->getElement();
+
+    ASSERT_NE(noApertureElement, nullptr);
+    ASSERT_NE(circleElement, nullptr);
+    ASSERT_NE(conicCircleElement, nullptr);
+
+    const std::vector<Vector_t> probes = {
+        Vector_t({0.00, 0.00, 0.20}),
+        Vector_t({0.20, 0.10, 1.00}),
+        Vector_t({0.49, 0.00, 0.20}),
+        Vector_t({0.49, 0.00, 1.00}),
+        Vector_t({0.49, 0.00, 1.80}),
+        Vector_t({0.50, 0.00, 1.00}),
+        Vector_t({0.00, 0.50, 1.00}),
+        Vector_t({0.36, 0.36, 1.00}),
+        Vector_t({0.40, 0.40, 1.00}),
+        Vector_t({0.00, 0.00, -0.10}),
+        Vector_t({0.00, 0.00, 2.00})
+    };
+
+    for (const Vector_t& r: probes) {
+        SCOPED_TRACE(::testing::Message()
+                     << "Probe point (" << r[0] << ", " << r[1] << ", " << r[2] << ")");
+        EXPECT_EQ(noApertureElement->isInside(r), circleElement->isInside(r));
+        EXPECT_EQ(noApertureElement->isInside(r), conicCircleElement->isInside(r));
+    }
+}
+
+TEST(OpalDriftTest, SquareAndRectangleEquivalentBehaviour) {
+    auto rectangle = makeDrift("RECTANGLE(1,1)");
+    auto conicRectangle = makeDrift("RECTANGLE(1,1,1)");
+    auto square = makeDrift("SQUARE(1)");
+    auto conicSquare = makeDrift("SQUARE(1,1)");
+
+    ElementBase* rectangleElement = rectangle->getElement();
+    ElementBase* conicRectangleElement = conicRectangle->getElement();
+    ElementBase* squareElement = square->getElement();
+    ElementBase* conicSquareElement = conicSquare->getElement();
+
+    ASSERT_NE(rectangleElement, nullptr);
+    ASSERT_NE(conicRectangleElement, nullptr);
+    ASSERT_NE(squareElement, nullptr);
+    ASSERT_NE(conicSquareElement, nullptr);
+
+    const std::vector<Vector_t> probes = {
+        Vector_t({0.00, 0.00, 0.20}),
+        Vector_t({0.49, 0.49, 1.00}),
+        Vector_t({0.49, 0.10, 1.80}),
+        Vector_t({0.10, 0.49, 0.20}),
+        Vector_t({0.50, 0.10, 1.00}),
+        Vector_t({0.10, 0.50, 1.00}),
+        Vector_t({0.60, 0.40, 1.00}),
+        Vector_t({0.40, 0.60, 1.00}),
+        Vector_t({0.00, 0.00, -0.10}),
+        Vector_t({0.00, 0.00, 2.00})
+    };
+
+    for (const Vector_t& r: probes) {
+        SCOPED_TRACE(::testing::Message()
+                     << "Probe point (" << r[0] << ", " << r[1] << ", " << r[2] << ")");
+        const bool expected = rectangleElement->isInside(r);
+        EXPECT_EQ(expected, conicRectangleElement->isInside(r));
+        EXPECT_EQ(expected, squareElement->isInside(r));
+        EXPECT_EQ(expected, conicSquareElement->isInside(r));
+    }
+}
+
+TEST(OpalDriftTest, ConicCircleOpeningBehaviour) {
+    auto conicCircle = makeDrift("CIRCLE(1,2)");
+    ElementBase* conicCircleElement = conicCircle->getElement();
+
+    ASSERT_NE(conicCircleElement, nullptr);
+
+    const Vector_t centerline({0.00, 0.00, 1.00});
+    EXPECT_TRUE(conicCircleElement->isInside(centerline));
+
+    // Radius starts at 0.5 m and grows linearly to 1.0 m at the exit.
+    const Vector_t startProbe({0.75, 0.00, 0.10});
+    const Vector_t middleProbe({0.75, 0.00, 1.00});
+    const Vector_t endProbe({0.75, 0.00, 1.90});
+
+    EXPECT_FALSE(conicCircleElement->isInside(startProbe));
+    EXPECT_FALSE(conicCircleElement->isInside(middleProbe));
+    EXPECT_TRUE(conicCircleElement->isInside(endProbe));
+}
+
+TEST(OpalDriftTest, ConicCircleClosingBehaviour) {
+    auto conicCircle = makeDrift("CIRCLE(1,0.5)");
+    ElementBase* conicCircleElement = conicCircle->getElement();
+
+    ASSERT_NE(conicCircleElement, nullptr);
+
+    // Radius starts at 0.5 m and shrinks linearly to 0.25 m at the exit.
+    const Vector_t startProbe({0.40, 0.00, 0.10});
+    const Vector_t middleProbe({0.40, 0.00, 1.00});
+    const Vector_t endProbe({0.40, 0.00, 1.90});
+
+    EXPECT_TRUE(conicCircleElement->isInside(startProbe));
+    EXPECT_FALSE(conicCircleElement->isInside(middleProbe));
+    EXPECT_FALSE(conicCircleElement->isInside(endProbe));
+}
+
+TEST(OpalDriftTest, CircleConstantAlongLengthAndLongitudinalBounds) {
+    auto circle = makeDrift("CIRCLE(1)");
+    ElementBase* circleElement = circle->getElement();
+
+    ASSERT_NE(circleElement, nullptr);
+
+    // Same transverse position should give the same result at multiple z inside the element.
+    const std::vector<Vector_t> insideTransverseInsideLength = {
+        Vector_t({0.49, 0.00, 0.10}),
+        Vector_t({0.49, 0.00, 1.00}),
+        Vector_t({0.49, 0.00, 1.90})
+    };
+    for (const Vector_t& r: insideTransverseInsideLength) {
+        EXPECT_TRUE(circleElement->isInside(r));
+    }
+
+    const std::vector<Vector_t> outsideTransverseInsideLength = {
+        Vector_t({0.51, 0.00, 0.10}),
+        Vector_t({0.51, 0.00, 1.00}),
+        Vector_t({0.51, 0.00, 1.90})
+    };
+    for (const Vector_t& r: outsideTransverseInsideLength) {
+        EXPECT_FALSE(circleElement->isInside(r));
+    }
+
+    // Before and after the element in z should always be outside, even on axis.
+    EXPECT_FALSE(circleElement->isInside(Vector_t({0.00, 0.00, -0.10})));
+    EXPECT_FALSE(circleElement->isInside(Vector_t({0.00, 0.00, 2.00})));
+}


### PR DESCRIPTION
Closes #1745 

This pull request introduces several improvements and fixes related to the handling and validation of conic apertures in beamline elements, as well as adds new unit tests for the `OpalDrift` element. The main themes are enhanced aperture parsing and validation, improved aperture interpolation logic, and expanded test coverage.

**Aperture parsing and validation improvements:**

* Improved regular expressions in `OpalElement::getApert()` to more robustly parse aperture arguments, handling whitespace and ensuring correct matching.
* Added a `validateConicScale` lambda to check that the conic aperture scale parameter is positive, throwing an exception if invalid; this validation is now called for all conic aperture types.

**Aperture interpolation logic:**

* Updated `ElementBase::isInsideTransverse()` to clamp the longitudinal fraction between 0 and 1 and interpolate the aperture scaling factor linearly from the entrance to the exit of conic elements, improving accuracy for conic rectangular and elliptical apertures.

**Testing and coverage:**

* Added a new test file `OpalDriftTest.cpp` with comprehensive unit tests for the `OpalDrift` element, covering default behavior, equivalence of square and rectangle apertures, conic aperture opening/closing, and longitudinal bounds.
