### PR TITLE
Resolve "Fix GCC 14 compilation errors"

### DIFF
--- a/ippl/src/FFT/FFTBase.hpp
+++ b/ippl/src/FFT/FFTBase.hpp
@@ -87,7 +87,7 @@ void FFTBase<Dim,T>::write(std::ostream& out) const {
     out << "---------------FFT Object Dump Begin-------------------" << std::endl;
     // Output the user-defined names for transform directions:
     out << "Map of transform direction names:" << std::endl;
-    std::map<char*,unsigned>::const_iterator mi, m_end = directions_m.end();
+    std::map<const char*,int>::const_iterator mi, m_end = directions_m.end();
     for (mi = directions_m.begin(); mi != m_end; ++mi)
         out << "[" << (*mi).first << "," << (*mi).second << "]" << std::endl;
     // Output type of transform

--- a/ippl/src/Field/GuardCellSizes.h
+++ b/ippl/src/Field/GuardCellSizes.h
@@ -31,7 +31,7 @@ public:
   GuardCellSizes(unsigned *s);
   GuardCellSizes(unsigned l, unsigned r);
   GuardCellSizes(unsigned *l, unsigned *r);
-  constexpr GuardCellSizes<Dim>(const GuardCellSizes<Dim>&) = default;
+  constexpr GuardCellSizes(const GuardCellSizes<Dim>&) = default;
   GuardCellSizes<Dim>& operator=(const GuardCellSizes<Dim>& gc)
   {
     for (unsigned d=0; d<Dim; ++d) {

--- a/src/Structure/BoundaryGeometry.cpp
+++ b/src/Structure/BoundaryGeometry.cpp
@@ -1952,8 +1952,8 @@ Change orientation if diff is:
         // helper for function  makeTriangleNormalInwardPointing()
         static void orientTriangle (BoundaryGeometry* bg, int ref_id, int triangle_id) {
             // find pts of common edge
-            int ic[2];
-            int id[2];
+            int ic[2] = {0, 0};
+            int id[2] = {0, 0};
             int n = 0;
             for (int i = 1; i <= 3; i++) {
                 for (int j = 1; j <= 3; j++) {


### PR DESCRIPTION
Closes #1751

This pull request includes several minor improvements and corrections to type declarations and variable initializations to enhance code safety and maintainability.

Type and declaration corrections:

* [`ippl/src/FFT/FFTBase.hpp`](diffhunk://#diff-29e9e8fbec8b9f3b0efbeb1746ff1e0e91a9a0d133b651e8a8b7de3356080ad4L90-R90): Corrected the iterator type for the `directions_m` map to use `const char*` keys and `int` values, improving type safety and consistency.
* [`ippl/src/Field/GuardCellSizes.h`](diffhunk://#diff-861d13a2c2fb04332c27b375ca7d6e0dec11f3318c38e325e55d776a1d83f5e7L34-R34): Fixed the syntax of the copy constructor declaration for `GuardCellSizes` to remove redundant template parameters and ensure proper usage.

Variable initialization improvements:

* [`src/Structure/BoundaryGeometry.cpp`](diffhunk://#diff-961679310683d99291e06591a3b6c50426b9cdd029fbc9d782e6ecaeca663b22L1955-R1956): Added explicit zero-initialization for arrays `ic` and `id` in the `orientTriangle` helper function, preventing potential use of uninitialized values.