### PR TITLE
Resolve "Build fixes for GCC-15"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ endif ()
 
 if (${WILL_BUILD_SHARED_LIBRARY})
     add_compile_options (-fPIE -fPIC)
-    add_link_options (-pie)
     # force OPAL to link to shared libraries
     if (UNIX)
         set(CMAKE_FIND_LIBRARY_SUFFIXES ".so")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,9 @@ add_library(libOPALObj OBJECT ${OPAL_SRCS})
 set_property(TARGET libOPALObj PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 add_executable (opal Main.cpp)
+if (WILL_BUILD_SHARED_LIBRARY)
+    target_link_options(opal PRIVATE -pie)
+endif()
 
 set (OPAL_LIBS
     ${SAAMG_SOLVER_LIBS}

--- a/src/Classic/FixedAlgebra/TransportFun.hpp
+++ b/src/Classic/FixedAlgebra/TransportFun.hpp
@@ -393,7 +393,7 @@ std::istream &TransportFun<T, N>::get(std::istream &is) {
 
 template <class T, int N>
 std::ostream &TransportFun<T, N>::put(std::ostream &os) const {
-    os << "Tps " << this->itsRep->max << ' ' << this->itsRep->trc << ' ' << N
+    os << "Tps " << 2 << ' ' << 2 << ' ' << N
        << std::endl;
     std::streamsize old_prec = os.precision(14);
     os.setf(std::ios::scientific, std::ios::floatfield);

--- a/src/Classic/FixedAlgebra/TransportFun.hpp
+++ b/src/Classic/FixedAlgebra/TransportFun.hpp
@@ -393,8 +393,11 @@ std::istream &TransportFun<T, N>::get(std::istream &is) {
 
 template <class T, int N>
 std::ostream &TransportFun<T, N>::put(std::ostream &os) const {
-    os << "Tps " << 2 << ' ' << 2 << ' ' << N
-       << std::endl;
+    // TransportFun is a fixed second-order polynomial container (constant,
+    // linear, and quadratic terms only), so max/truncation orders are always 2.
+    // Older code used FTps-style `itsRep` fields by analogy, but TransportFun
+    // has no dynamic representation object.
+    os << "Tps " << 2 << ' ' << 2 << ' ' << N << std::endl;
     std::streamsize old_prec = os.precision(14);
     os.setf(std::ios::scientific, std::ios::floatfield);
 

--- a/src/PyOpal/PyCore/PyOpalObject.h
+++ b/src/PyOpal/PyCore/PyOpalObject.h
@@ -390,7 +390,13 @@ boost::python::object PyOpalObject<C>::setAttributes(boost::python::tuple args,
     boost::python::list key_list = kwargs.keys();
     for (boost::python::ssize_t i = 0; i < boost::python::len(key_list); ++i) {
         boost::python::object key = key_list[i];
-        std::string keyStr = boost::python::extract<std::string>(key);
+        boost::python::object keyObjStr = boost::python::str(key);
+        boost::python::extract<const char*> keyExtract(keyObjStr);
+        if (!keyExtract.check()) {
+            throw OpalException("PyOpalObject::setAttributes",
+                                "Attribute key is not convertible to string");
+        }
+        std::string keyStr(keyExtract());
         boost::python::object value = kwargs[key];
         if (PyOpalObject<C>::pyNameToAttribute.find(keyStr) ==
                                     PyOpalObject<C>::pyNameToAttribute.end()) {


### PR DESCRIPTION
Closes #1753 

**Build system improvements:**

* Moved the `-pie` linker option from the global shared library build context in `CMakeLists.txt` to be applied only to the `opal` executable target in `src/CMakeLists.txt`, ensuring more precise and appropriate application of linker flags.

**Python bindings robustness:**

* Improved error handling in `PyOpalObject::setAttributes` by explicitly checking if attribute keys are convertible to strings and throwing a descriptive exception if not, preventing potential runtime errors.

**Output consistency:**

* Fixed the `put` method in `TransportFun` to output constant values (`2 2`) instead of using possibly uninitialized or incorrect member variables, ensuring consistent and predictable serialization output.