### PR TITLE
Resolve "Writing initial distribution fails in multicore case"

### DIFF
--- a/src/Distribution/Distribution.cpp
+++ b/src/Distribution/Distribution.cpp
@@ -4185,13 +4185,15 @@ void Distribution::writeOutFileHeader() {
 
     unsigned int totalNum = tOrZDist_m.size();
     reduce(totalNum, totalNum, OpAddAssign());
-    if (Ippl::myNode() != 0)
-        return;
 
+    // Every node needs outFilename_m, e.g. to append its own particles later on.
     outFilename_m = Util::combineFilePath({
         OpalData::getInstance()->getAuxiliaryOutputDirectory(),
         OpalData::getInstance()->getInputBasename() + "_" + getOpalName() + ".dat"
     });
+
+    if (Ippl::myNode() != 0)
+        return;
 
     std::ofstream outputFile(outFilename_m);
     if (outputFile.bad()) {


### PR DESCRIPTION
Closes #999

`outFilename_m` is now computed identically on every rank, before the rank-0-only early return. Previously it stayed empty on ranks ≠ 0, so `writeOutFileInjection` silently failed to open the file on those ranks and only rank 0's share of particles was ever written. Now every rank has the correct filename and the round-robin write loop in writeOutFileInjection correctly appends every rank's particles.